### PR TITLE
assert

### DIFF
--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -33,7 +33,8 @@ __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"
 
-assert (isinstance(ase.__file__, str))
+if not (isinstance(ase.__file__, str)):
+    raise AssertionError()
 
 s = Settings()
 


### PR DESCRIPTION
It was discovered that some projects used assert to enforce interface constraints. However, assert is removed with compiling to optimised byte code (python -o producing *.pyo files). This caused various protections to be removed. The use of assert is also considered as general bad practice in OpenStack codebases.