### PR TITLE
excluded interactive from exclude_group so that the interactive class…

### DIFF
--- a/pyiron/base/generic/hdfio.py
+++ b/pyiron/base/generic/hdfio.py
@@ -575,7 +575,7 @@ class FileHDFio(object):
             self.hd_copy(hdf_old[p], h_new, exclude_groups=exclude_groups)
         return hdf_new
 
-    def rewrite_hdf5(self, job_name, info=False, exclude_groups=['interactive']):
+    def rewrite_hdf5(self, job_name, info=False, exclude_groups=[]):
         """
         args:
             info (True/False): whether to give the information on how much space has been saved


### PR DESCRIPTION
… is also saved.

This follows a discussion between Jan and me.