### PR TITLE
Compress all output files by default

### DIFF
--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -142,6 +142,7 @@ class GenericJob(JobCore):
         self._restart_file_list = list()
         self._restart_file_dict = dict()
         self._process = None
+        self._compress_by_default = False
 
         for sig in intercepted_signals:
             signal.signal(sig,  self.signal_intercept)
@@ -1039,6 +1040,8 @@ class GenericJob(JobCore):
                 self.status.not_converged = True
             else:
                 self.status.finished = True
+        if self._compress_by_default:
+            self.compress()
         self._calculate_successor()
         self.send_to_database()
         self.update_master()

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1039,9 +1039,9 @@ class GenericJob(JobCore):
             if not self.convergence_check():
                 self.status.not_converged = True
             else:
+                if self._compress_by_default:
+                    self.compress()
                 self.status.finished = True
-        if self._compress_by_default:
-            self.compress()
         self._calculate_successor()
         self.send_to_database()
         self.update_master()

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -55,6 +55,7 @@ class LammpsBase(AtomisticGenericJob):
         self.input = Input()
         self._cutoff_radius = None
         self._is_continuation = None
+        self._compress_by_default = True
 
     @property
     def cutoff_radius(self):
@@ -497,6 +498,17 @@ class LammpsBase(AtomisticGenericJob):
 
         """
         self.input.control.modify(write_restart=filename, append_if_not_present=True)
+
+    def compress(self, files_to_compress=None):
+        """
+        Compress the output files of a job object.
+
+        Args:
+            files_to_compress (list):
+        """
+        if files_to_compress is None:
+            files_to_compress = [f for f in list(self.list_files()) if f not in ["restart.out"]]
+        super(LammpsBase, self).compress(files_to_compress=files_to_compress)
 
     def read_restart_file(self, filename="restart.out"):
         """

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -79,6 +79,7 @@ class VaspBase(GenericDFTJob):
         self.input.incar["SYSTEM"] = self.job_name
         self._output_parser = Output()
         self._potential = VaspPotentialFile(xc=self.input.potcar["xc"])
+        self._compress_by_default = True
 
     @property
     def potential(self):
@@ -895,6 +896,17 @@ class VaspBase(GenericDFTJob):
             else:
                 new_ham.input.incar["ICHARG"] = icharg
         return new_ham
+
+    def compress(self, files_to_compress=None):
+        """
+        Compress the output files of a job object.
+
+        Args:
+            files_to_compress (list):
+        """
+        if files_to_compress is None:
+            files_to_compress = [f for f in list(self.list_files()) if f not in ["CHGCAR", "WAVECAR"]]
+        super(VaspBase, self).compress(files_to_compress=files_to_compress)
 
     def restart_from_wave_functions(self, snapshot=-1, job_name=None, job_type=None, istart=1):
 


### PR DESCRIPTION
Restart files are not compressed, in addition only job types which have self._compress_by_default enabled compress their output files.