### PR TITLE
Write traj

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -18,10 +18,6 @@ try:
 except (ImportError, TypeError, AttributeError):
     pass
 
-"""
-Atomistic Generic Job class extends the Generic Job class with all the functionality to run jobs containing atomistic structures.
-"""
-
 __author__ = "Jan Janssen"
 __copyright__ = "Copyright 2019, Max-Planck-Institut für Eisenforschung GmbH - " \
                 "Computational Materials Design (CM) Department"

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -590,7 +590,7 @@ class Trajectory(object):
         new_structure.positions = self._positions[item]
         # This step is necessary for using ase.io.write for trajectories
         new_structure.arrays['positions'] = new_structure.positions
-        new_structure.arrays['cells'] = new_structure.cell
+        # new_structure.arrays['cells'] = new_structure.cell
         return new_structure
 
     def __len__(self):

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -423,14 +423,14 @@ class AtomisticGenericJob(GenericJobCore):
                               self.structure.get_parent_basis()[atom_indices], center_of_mass=center_of_mass,
                               cells=cells[::stride])
 
-    def write_traj(self, filename, format=None, parallel=True, append=False, stride=1, center_of_mass=False,
+    def write_traj(self, filename, file_format=None, parallel=True, append=False, stride=1, center_of_mass=False,
                    atom_indices=None, snapshot_indices=None, **kwargs):
         """
-        Writes the trajectory in a given file format based on the `ase.io.write`_ function.
+        Writes the trajectory in a given file file_format based on the `ase.io.write`_ function.
 
         Args:
             filename (str): Filename of the output
-            format (str): The specific format of the output
+            file_format (str): The specific file_format of the output
             parallel (bool):
             append (bool):
             stride (int): Writes trajectory every `stride` steps
@@ -444,7 +444,7 @@ class AtomisticGenericJob(GenericJobCore):
         traj = self.trajectory(stride=stride, center_of_mass=center_of_mass, atom_indices=atom_indices,
                                snapshot_indices=snapshot_indices)
         # Using thr ASE output writer
-        ase_write(filename=filename, images=traj, format=format,  parallel=parallel, append=append, **kwargs)
+        ase_write(filename=filename, images=traj, format=file_format, parallel=parallel, append=append, **kwargs)
 
     def _run_if_lib_save(self, job_name=None, structure=None, db_entry=True):
         """

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -513,7 +513,7 @@ class AtomisticGenericJob(GenericJobCore):
             iteration_step (int): Step for which the structure is requested
 
         Returns:
-            atomistics.structure.atoms.Atoms object
+            pyiron.atomistics.structure.atoms.Atoms: The required structure
         """
         if not (self.structure is not None):
             raise AssertionError()
@@ -521,7 +521,7 @@ class AtomisticGenericJob(GenericJobCore):
         snapshot.cell = self.get("output/generic/cells")[iteration_step]
         snapshot.positions = self.get("output/generic/positions")[iteration_step]
         indices = self.get("output/generic/indices")
-        if indices is not None: 
+        if indices is not None:
             snapshot.indices = indices[iteration_step]
         return snapshot
 


### PR DESCRIPTION
Now trajectories can be written to any output format by the ase writer with added features of selecting the atoms and the exact time steps for which we want the animation!