### PR TITLE
Langevin fix

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -200,8 +200,9 @@ class AtomisticGenericJob(GenericJobCore):
         self._generic_input['calc_mode'] = 'static'
         self._generic_input.remove_keys(['max_iter', 'pressure', 'temperature', 'n_ionic_steps', 'n_print', 'velocity'])
 
-    def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=None, n_print=100, delta_temp=1.0,
-                delta_press=None, seed=None, tloop=None, initial_temperature=True, langevin=False):
+    def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=None, n_print=100,
+                temperature_damping=1.0, pressure_damping=None, seed=None, tloop=None, initial_temperature=True,
+                langevin=False):
         self._generic_input['calc_mode'] = 'md'
         self._generic_input['temperature'] = temperature
         self._generic_input['n_ionic_steps'] = n_ionic_steps

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -427,7 +427,8 @@ class LammpsBase(AtomisticGenericJob):
         self.input.control.calc_static()
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                delta_temp=100.0, delta_press=1000.0, seed=None, tloop=None, initial_temperature=None, langevin=False):
+                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
+                langevin=False):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
 
@@ -439,8 +440,8 @@ class LammpsBase(AtomisticGenericJob):
             n_ionic_steps: (int) Number of ionic steps
             time_step: (float) Step size between two steps. In fs if units==metal
             n_print: (int) Print frequency
-            delta_temp: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            delta_press: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_damping: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            pressure_damping: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
             seed: (int) Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature: (None or float) Initial temperature according to which the initial velocity field
@@ -452,11 +453,13 @@ class LammpsBase(AtomisticGenericJob):
             langevin: (True or False) Activate Langevin dynamics
         """
         super(LammpsBase, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                        time_step=time_step, n_print=n_print, delta_temp=delta_temp,
-                                        delta_press=delta_press,
-                                        seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin)
+                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
+                                        pressure_damping=pressure_damping,
+                                        seed=seed, tloop=tloop, initial_temperature=initial_temperature,
+                                        langevin=langevin)
         self.input.control.calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                   time_step=time_step, n_print=n_print, delta_temp=delta_temp, delta_press=delta_press,
+                                   time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
+                                   pressure_damping=pressure_damping,
                                    seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin)
 
     # define hdf5 input and output

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -428,7 +428,7 @@ class LammpsBase(AtomisticGenericJob):
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
                 temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
-                langevin=False):
+                langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
 
@@ -460,7 +460,8 @@ class LammpsBase(AtomisticGenericJob):
         self.input.control.calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
                                    time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
                                    pressure_damping=pressure_damping,
-                                   seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin)
+                                   seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin,
+                                   delta_temp=delta_temp, delta_press=delta_press)
 
     # define hdf5 input and output
     def to_hdf(self, hdf=None, group_name=None):

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -144,7 +144,7 @@ class LammpsControl(GenericParameters):
             print("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
             temperature_damping = delta_temp
         if delta_press is not None:
-            print("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
+            print("WARNING: `delta_press` is deprecated, please use `pressure_damping`")
             temperature_damping = delta_press
 
         if time_step is not None:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -191,10 +191,10 @@ class LammpsControl(GenericParameters):
                 raise ValueError('Target temperature for fix nvt/npt/nph cannot be 0.0')
             if langevin:
                 fix_ensemble_str = 'all nve'
-                self.modify(fix___langevin='all langevin {0} {1} {2} {3}'.format(str(temperature),
-                                                                                 str(temperature),
-                                                                                 str(temperature_damping),
-                                                                                 str(seed)),
+                self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
+                                                                                          str(temperature),
+                                                                                          str(temperature_damping),
+                                                                                          str(seed)),
                             append_if_not_present=True)
             else:
                 fix_ensemble_str = 'all nvt temp {0} {1} {2}'.format(str(temperature),

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -173,7 +173,7 @@ class LammpsControl(GenericParameters):
                 fix_ensemble_str = 'all nph aniso {0} {1} {2}'.format(str(pressure),
                                                                       str(pressure),
                                                                       str(pressure_damping))
-                self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero no'.format(str(temperature),
+                self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
                                                                                           str(temperature),
                                                                                           str(temperature_damping),
                                                                                           str(seed)),

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -115,8 +115,7 @@ class LammpsControl(GenericParameters):
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
                 temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
-                langevin=False,
-                ):
+                langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
 
@@ -141,6 +140,12 @@ class LammpsControl(GenericParameters):
                                                for the initial temperature.
             langevin (bool): (True or False) Activate Langevin dynamics
         """
+        if delta_temp is not None:
+            print("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
+            temperature_damping = delta_temp
+        if delta_press is not None:
+            print("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
+            temperature_damping = delta_press
 
         if time_step is not None:
             # time_step in fs

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -145,7 +145,7 @@ class LammpsControl(GenericParameters):
             temperature_damping = delta_temp
         if delta_press is not None:
             print("WARNING: `delta_press` is deprecated, please use `pressure_damping`")
-            temperature_damping = delta_press
+            pressure_damping = delta_press
 
         if time_step is not None:
             # time_step in fs

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 from collections import OrderedDict
 import numpy as np
+import warnings
 from pyiron.base.generic.parameters import GenericParameters
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal, Jan Janssen"
@@ -141,10 +142,10 @@ class LammpsControl(GenericParameters):
             langevin (bool): (True or False) Activate Langevin dynamics
         """
         if delta_temp is not None:
-            print("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
+            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
             temperature_damping = delta_temp
         if delta_press is not None:
-            print("WARNING: `delta_press` is deprecated, please use `pressure_damping`")
+            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_damping`")
             pressure_damping = delta_press
 
         if time_step is not None:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -173,7 +173,7 @@ class LammpsControl(GenericParameters):
                 fix_ensemble_str = 'all nph aniso {0} {1} {2}'.format(str(pressure),
                                                                       str(pressure),
                                                                       str(pressure_damping))
-                self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
+                self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero no'.format(str(temperature),
                                                                                           str(temperature),
                                                                                           str(temperature_damping),
                                                                                           str(seed)),

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -180,7 +180,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                                                      n_print=n_print)
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None, langevin=False):
+                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
+                langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
 
@@ -207,9 +208,11 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         if self.server.run_mode.interactive_non_modal:
             warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
         super(LammpsInteractive, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                               time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
+                                               time_step=time_step, n_print=n_print,
+                                               temperature_damping=temperature_damping,
                                                pressure_damping=pressure_damping, seed=seed, tloop=tloop,
-                                               initial_temperature=initial_temperature, langevin=langevin)
+                                               initial_temperature=initial_temperature, langevin=langevin,
+                                               delta_temp=delta_temp, delta_press=delta_press)
 
     def run_if_interactive(self):
         if self._generic_input['calc_mode'] == 'md':

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -180,7 +180,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                                                      n_print=n_print)
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                delta_temp=100.0, delta_press=1000.0, seed=None, tloop=None, initial_temperature=None, langevin=False):
+                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None, langevin=False):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
 
@@ -192,8 +192,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             n_ionic_steps: (int) Number of ionic steps
             time_step: (float) Step size between two steps. In fs if units==metal
             n_print: (int) Print frequency
-            delta_temp: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            delta_press: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_damping: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            pressure_damping: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
             seed: (int) Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature: (None or float) Initial temperature according to which the initial velocity field
@@ -207,8 +207,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         if self.server.run_mode.interactive_non_modal:
             warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
         super(LammpsInteractive, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                               time_step=time_step, n_print=n_print, delta_temp=delta_temp,
-                                               delta_press=delta_press, seed=seed, tloop=tloop,
+                                               time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
+                                               pressure_damping=pressure_damping, seed=seed, tloop=tloop,
                                                initial_temperature=initial_temperature, langevin=langevin)
 
     def run_if_interactive(self):


### PR DESCRIPTION
Adds the "zero yes" keyword argument to Lammps Langevin thermostat calls and renames some Lammps MD variables.

The key issue was that the Langevin thermostat adds random forces to the system, and without "zero yes" this can produce a net force on the centre of mass, causing drift over long simulations. Lammps already has the built-in keyword to prevent this. I'm not even making it optional because I don't see why you would ever want your CoM to drift!

I also renamed the `delta_temp` and `delta_press` variables to `temperature_damping` and `pressure_damping`, respectively. This is more in line with our "full name" naming scheme, and also (IMO) more intuitive since they have units of time and not units of $\Delta T$ or $\Delta P$. The original variable names are still usable but print a deprecation warning.