### PR TITLE
Langevin fix

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -198,8 +198,8 @@ class AtomisticGenericJob(GenericJobCore):
         self._generic_input.remove_keys(['max_iter', 'pressure', 'temperature', 'n_ionic_steps', 'n_print', 'velocity'])
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=None, n_print=100,
-                temperature_timescale=1.0, pressure_timescale=None, seed=None, tloop=None, initial_temperature=True,
-                langevin=False):
+                temperature_damping_timescale=100., pressure_damping_timescale=None, seed=None, tloop=None,
+                initial_temperature=True, langevin=False):
         self._generic_input['calc_mode'] = 'md'
         self._generic_input['temperature'] = temperature
         self._generic_input['n_ionic_steps'] = n_ionic_steps

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -198,7 +198,7 @@ class AtomisticGenericJob(GenericJobCore):
         self._generic_input.remove_keys(['max_iter', 'pressure', 'temperature', 'n_ionic_steps', 'n_print', 'velocity'])
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=None, n_print=100,
-                temperature_damping=1.0, pressure_damping=None, seed=None, tloop=None, initial_temperature=True,
+                temperature_timescale=1.0, pressure_timescale=None, seed=None, tloop=None, initial_temperature=True,
                 langevin=False):
         self._generic_input['calc_mode'] = 'md'
         self._generic_input['temperature'] = temperature

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -427,7 +427,7 @@ class LammpsBase(AtomisticGenericJob):
         self.input.control.calc_static()
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
+                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
                 langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
@@ -440,8 +440,8 @@ class LammpsBase(AtomisticGenericJob):
             n_ionic_steps: (int) Number of ionic steps
             time_step: (float) Step size between two steps. In fs if units==metal
             n_print: (int) Print frequency
-            temperature_damping: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_damping: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_timescale: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            pressure_timescale: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
             seed: (int) Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature: (None or float) Initial temperature according to which the initial velocity field
@@ -453,13 +453,13 @@ class LammpsBase(AtomisticGenericJob):
             langevin: (True or False) Activate Langevin dynamics
         """
         super(LammpsBase, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
-                                        pressure_damping=pressure_damping,
+                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_timescale,
+                                        pressure_damping=pressure_timescale,
                                         seed=seed, tloop=tloop, initial_temperature=initial_temperature,
                                         langevin=langevin)
         self.input.control.calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                   time_step=time_step, n_print=n_print, temperature_damping=temperature_damping,
-                                   pressure_damping=pressure_damping,
+                                   time_step=time_step, n_print=n_print, temperature_timescale=temperature_timescale,
+                                   pressure_timescale=pressure_timescale,
                                    seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin,
                                    delta_temp=delta_temp, delta_press=delta_press)
 

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -462,8 +462,9 @@ class LammpsBase(AtomisticGenericJob):
         if self.server.run_mode.interactive_non_modal:
             warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
         super(LammpsBase, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_damping_timescale,
-                                        pressure_damping=pressure_damping_timescale,
+                                        time_step=time_step, n_print=n_print,
+                                        temperature_damping_timescale=temperature_damping_timescale,
+                                        pressure_damping_timescale=pressure_damping_timescale,
                                         seed=seed, tloop=tloop, initial_temperature=initial_temperature,
                                         langevin=langevin)
         self.input.control.calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -427,39 +427,48 @@ class LammpsBase(AtomisticGenericJob):
         self.input.control.calc_static()
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
+                temperature_damping_timescale=100.0, pressure_damping_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
                 langevin=False, delta_temp=None, delta_press=None):
         """
-        Set an MD calculation within LAMMPS. Nosé Hoover is used by default
+        Set an MD calculation within LAMMPS. Nosé Hoover is used by default.
 
         Args:
-            temperature: (None or float) Target temperature. If set to None, an NVE calculation is performed.
-                         It is required when the pressure is set or langevin is set
-            pressure: (None or float) Target pressure. If set to None, an NVE or an NVT calculation is performed.
-                      (This tag will allow for a list in the future as it is done for calc_minimize())
-            n_ionic_steps: (int) Number of ionic steps
-            time_step: (float) Step size between two steps. In fs if units==metal
-            n_print: (int) Print frequency
-            temperature_timescale: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_timescale: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            seed: (int) Seed for the random number generation (required for the velocity creation)
+            temperature (None/float): Target temperature. If set to None, an NVE calculation is performed.
+                                      It is required when the pressure is set or langevin is set
+            pressure (None/float): Target pressure. If set to None, an NVE or an NVT calculation is performed.
+                                   (This tag will allow for a list in the future as it is done for calc_minimize())
+            n_ionic_steps (int): Number of ionic steps
+            time_step (float): Step size between two steps. In fs if units==metal
+            n_print (int):  Print frequency
+            temperature_damping_timescale (float): The time associated with the thermostat adjusting the temperature.
+                                                   (In fs. After rescaling to appropriate time units, is equivalent to
+                                                   Lammps' `Tdamp`.)
+            pressure_damping_timescale (float): The time associated with the barostat adjusting the temperature.
+                                                (In fs. After rescaling to appropriate time units, is equivalent to
+                                                Lammps' `Pdamp`.)
+            seed (int):  Seed for the random number generation (required for the velocity creation)
             tloop:
-            initial_temperature: (None or float) Initial temperature according to which the initial velocity field
-                                 is created. If None, the initial temperature will be twice the target temperature
-                                 (which would go immediately down to the target temperature as described in
-                                 equipartition theorem). If 0, the velocity field is not initialized (in which case
-                                 the initial velocity given in structure will be used). If any other number is given,
-                                 this value is going to be used for the initial temperature.
-            langevin: (True or False) Activate Langevin dynamics
+            initial_temperature (None/float):  Initial temperature according to which the initial velocity field
+                                               is created. If None, the initial temperature will be twice the target
+                                               temperature (which would go immediately down to the target temperature
+                                               as described in equipartition theorem). If 0, the velocity field is not
+                                               initialized (in which case  the initial velocity given in structure will
+                                               be used). If any other number is given, this value is going to be used
+                                               for the initial temperature.
+            langevin (bool): (True or False) Activate Langevin dynamics
+            delta_temp (float): Thermostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
+            delta_press (float): Barostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
         """
+        if self.server.run_mode.interactive_non_modal:
+            warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
         super(LammpsBase, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_timescale,
-                                        pressure_damping=pressure_timescale,
+                                        time_step=time_step, n_print=n_print, temperature_damping=temperature_damping_timescale,
+                                        pressure_damping=pressure_damping_timescale,
                                         seed=seed, tloop=tloop, initial_temperature=initial_temperature,
                                         langevin=langevin)
         self.input.control.calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                   time_step=time_step, n_print=n_print, temperature_timescale=temperature_timescale,
-                                   pressure_timescale=pressure_timescale,
+                                   time_step=time_step, n_print=n_print, temperature_damping_timescale=temperature_damping_timescale,
+                                   pressure_damping_timescale=pressure_damping_timescale,
                                    seed=seed, tloop=tloop, initial_temperature=initial_temperature, langevin=langevin,
                                    delta_temp=delta_temp, delta_press=delta_press)
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -115,10 +115,10 @@ class LammpsControl(GenericParameters):
                     append_if_not_present=True)
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
-                langevin=False, delta_temp=None, delta_press=None):
+                temperature_damping_timescale=100.0, pressure_damping_timescale=1000.0, seed=None, tloop=None,
+                initial_temperature=None, langevin=False, delta_temp=None, delta_press=None):
         """
-        Set an MD calculation within LAMMPS. Nosé Hoover is used by default
+        Set an MD calculation within LAMMPS. Nosé Hoover is used by default.
 
         Args:
             temperature (None/float): Target temperature. If set to None, an NVE calculation is performed.
@@ -128,8 +128,12 @@ class LammpsControl(GenericParameters):
             n_ionic_steps (int): Number of ionic steps
             time_step (float): Step size between two steps. In fs if units==metal
             n_print (int):  Print frequency
-            temperature_timescale (float):  Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_timescale (float): Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_damping_timescale (float): The time associated with the thermostat adjusting the temperature.
+                                                   (In fs. After rescaling to appropriate time units, is equivalent to
+                                                   Lammps' `Tdamp`.)
+            pressure_damping_timescale (float): The time associated with the barostat adjusting the temperature.
+                                                (In fs. After rescaling to appropriate time units, is equivalent to
+                                                Lammps' `Pdamp`.)
             seed (int):  Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature (None/float):  Initial temperature according to which the initial velocity field
@@ -140,24 +144,39 @@ class LammpsControl(GenericParameters):
                                                be used). If any other number is given, this value is going to be used
                                                for the initial temperature.
             langevin (bool): (True or False) Activate Langevin dynamics
+            delta_temp (float): Thermostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
+            delta_press (float): Barostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
         """
         if delta_temp is not None:
-            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_timescale`")
-            temperature_timescale = delta_temp
+            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_damping_timescale`")
+            temperature_damping_timescale = delta_temp
         if delta_press is not None:
-            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_timescale`")
-            pressure_timescale = delta_press
+            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_damping_timescale`")
+            pressure_damping_timescale = delta_press
+
+        time_rescaling_factors = {'metal': 1e-3,
+                                  'si': 1e-12,
+                                  'cgs': 1e-12,
+                                  'real': 1,
+                                  'electron': 1}
 
         if time_step is not None:
-            # time_step in fs
-            if self['units'] == 'metal':
-                self['timestep'] = time_step * 1e-3  # lammps in ps
-            elif self['units'] in ['si', 'cgs']:
-                self['timestep'] = time_step * 1e-12
-            elif self['units'] in ['real', 'electron']:
-                self['timestep'] = time_step
-            else:
+            try:
+                self['timestep'] = time_step * time_rescaling_factors[self['units']]
+            except KeyError:
                 raise NotImplementedError()
+
+        if delta_temp is not None:
+            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_damping_timescale`.")
+            temperature_damping_timescale = delta_temp
+        else:
+            temperature_damping_timescale *= time_rescaling_factors[self['units']]
+
+        if delta_press is not None:
+            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_damping_timescale`.")
+            pressure_damping_timescale = delta_press / time_rescaling_factors[self['units']]
+        else:
+            pressure_damping_timescale *= time_rescaling_factors[self['units']]
 
         if initial_temperature is None and temperature is not None:
             initial_temperature = 2*temperature
@@ -166,26 +185,26 @@ class LammpsControl(GenericParameters):
             seed = np.random.randint(99999)
         if pressure is not None:
             pressure = float(pressure)*1.0e4  # TODO; why needed?
-            if pressure_timescale is None:
-                pressure_timescale = temperature_timescale * 10
+            if pressure_damping_timescale is None:
+                pressure_damping_timescale = temperature_damping_timescale * 10
             if temperature is None or temperature == 0.0:
                 raise ValueError('Target temperature for fix nvt/npt/nph cannot be 0.0')
             if langevin:
                 fix_ensemble_str = 'all nph aniso {0} {1} {2}'.format(str(pressure),
                                                                       str(pressure),
-                                                                      str(pressure_timescale))
+                                                                      str(pressure_damping_timescale))
                 self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
                                                                                           str(temperature),
-                                                                                          str(temperature_timescale),
+                                                                                          str(temperature_damping_timescale),
                                                                                           str(seed)),
                             append_if_not_present=True)
             else:
                 fix_ensemble_str = 'all npt temp {0} {1} {2} aniso {3} {4} {5}'.format(str(temperature),
                                                                                        str(temperature),
-                                                                                       str(temperature_timescale),
+                                                                                       str(temperature_damping_timescale),
                                                                                        str(pressure),
                                                                                        str(pressure),
-                                                                                       str(pressure_timescale))
+                                                                                       str(pressure_damping_timescale))
         elif temperature is not None:
             temperature = float(temperature)  # TODO; why needed?
             if temperature == 0.0:
@@ -194,13 +213,13 @@ class LammpsControl(GenericParameters):
                 fix_ensemble_str = 'all nve'
                 self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
                                                                                           str(temperature),
-                                                                                          str(temperature_timescale),
+                                                                                          str(temperature_damping_timescale),
                                                                                           str(seed)),
                             append_if_not_present=True)
             else:
                 fix_ensemble_str = 'all nvt temp {0} {1} {2}'.format(str(temperature),
                                                                      str(temperature),
-                                                                     str(temperature_timescale))
+                                                                     str(temperature_damping_timescale))
         else:
             fix_ensemble_str = 'all nve'
             initial_temperature = 0

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -115,7 +115,7 @@ class LammpsControl(GenericParameters):
                     append_if_not_present=True)
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
+                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
                 langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
@@ -128,8 +128,8 @@ class LammpsControl(GenericParameters):
             n_ionic_steps (int): Number of ionic steps
             time_step (float): Step size between two steps. In fs if units==metal
             n_print (int):  Print frequency
-            temperature_damping (float):  Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_damping (float): Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_timescale (float):  Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            pressure_timescale (float): Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
             seed (int):  Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature (None/float):  Initial temperature according to which the initial velocity field
@@ -142,11 +142,11 @@ class LammpsControl(GenericParameters):
             langevin (bool): (True or False) Activate Langevin dynamics
         """
         if delta_temp is not None:
-            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_damping`")
-            temperature_damping = delta_temp
+            warnings.warn("WARNING: `delta_temp` is deprecated, please use `temperature_timescale`")
+            temperature_timescale = delta_temp
         if delta_press is not None:
-            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_damping`")
-            pressure_damping = delta_press
+            warnings.warn("WARNING: `delta_press` is deprecated, please use `pressure_timescale`")
+            pressure_timescale = delta_press
 
         if time_step is not None:
             # time_step in fs
@@ -166,26 +166,26 @@ class LammpsControl(GenericParameters):
             seed = np.random.randint(99999)
         if pressure is not None:
             pressure = float(pressure)*1.0e4  # TODO; why needed?
-            if pressure_damping is None:
-                pressure_damping = temperature_damping * 10
+            if pressure_timescale is None:
+                pressure_timescale = temperature_timescale * 10
             if temperature is None or temperature == 0.0:
                 raise ValueError('Target temperature for fix nvt/npt/nph cannot be 0.0')
             if langevin:
                 fix_ensemble_str = 'all nph aniso {0} {1} {2}'.format(str(pressure),
                                                                       str(pressure),
-                                                                      str(pressure_damping))
+                                                                      str(pressure_timescale))
                 self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
                                                                                           str(temperature),
-                                                                                          str(temperature_damping),
+                                                                                          str(temperature_timescale),
                                                                                           str(seed)),
                             append_if_not_present=True)
             else:
                 fix_ensemble_str = 'all npt temp {0} {1} {2} aniso {3} {4} {5}'.format(str(temperature),
                                                                                        str(temperature),
-                                                                                       str(temperature_damping),
+                                                                                       str(temperature_timescale),
                                                                                        str(pressure),
                                                                                        str(pressure),
-                                                                                       str(pressure_damping))
+                                                                                       str(pressure_timescale))
         elif temperature is not None:
             temperature = float(temperature)  # TODO; why needed?
             if temperature == 0.0:
@@ -194,13 +194,13 @@ class LammpsControl(GenericParameters):
                 fix_ensemble_str = 'all nve'
                 self.modify(fix___langevin='all langevin {0} {1} {2} {3} zero yes'.format(str(temperature),
                                                                                           str(temperature),
-                                                                                          str(temperature_damping),
+                                                                                          str(temperature_timescale),
                                                                                           str(seed)),
                             append_if_not_present=True)
             else:
                 fix_ensemble_str = 'all nvt temp {0} {1} {2}'.format(str(temperature),
                                                                      str(temperature),
-                                                                     str(temperature_damping))
+                                                                     str(temperature_timescale))
         else:
             fix_ensemble_str = 'all nve'
             initial_temperature = 0

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -180,7 +180,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                                                      n_print=n_print)
 
     def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_damping=100.0, pressure_damping=1000.0, seed=None, tloop=None, initial_temperature=None,
+                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
                 langevin=False, delta_temp=None, delta_press=None):
         """
         Set an MD calculation within LAMMPS. Nosé Hoover is used by default
@@ -193,8 +193,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             n_ionic_steps: (int) Number of ionic steps
             time_step: (float) Step size between two steps. In fs if units==metal
             n_print: (int) Print frequency
-            temperature_damping: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_damping: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            temperature_timescale: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
+            pressure_timescale: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
             seed: (int) Seed for the random number generation (required for the velocity creation)
             tloop:
             initial_temperature: (None or float) Initial temperature according to which the initial velocity field
@@ -209,8 +209,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
         super(LammpsInteractive, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
                                                time_step=time_step, n_print=n_print,
-                                               temperature_damping=temperature_damping,
-                                               pressure_damping=pressure_damping, seed=seed, tloop=tloop,
+                                               temperature_timescale=temperature_timescale,
+                                               pressure_timescale=pressure_timescale, seed=seed, tloop=tloop,
                                                initial_temperature=initial_temperature, langevin=langevin,
                                                delta_temp=delta_temp, delta_press=delta_press)
 

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -179,41 +179,6 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         super(LammpsInteractive, self).calc_minimize(e_tol=e_tol, f_tol=f_tol, max_iter=max_iter, pressure=pressure,
                                                      n_print=n_print)
 
-    def calc_md(self, temperature=None, pressure=None, n_ionic_steps=1000, time_step=1.0, n_print=100,
-                temperature_timescale=100.0, pressure_timescale=1000.0, seed=None, tloop=None, initial_temperature=None,
-                langevin=False, delta_temp=None, delta_press=None):
-        """
-        Set an MD calculation within LAMMPS. Nosé Hoover is used by default
-
-        Args:
-            temperature: (None or float) Target temperature. If set to None, an NVE calculation is performed.
-                         It is required when the pressure is set or langevin is set
-            pressure: (None or float) Target pressure. If set to None, an NVE or an NVT calculation is performed.
-                      (This tag will allow for a list in the future as it is done for calc_minimize())
-            n_ionic_steps: (int) Number of ionic steps
-            time_step: (float) Step size between two steps. In fs if units==metal
-            n_print: (int) Print frequency
-            temperature_timescale: (float) Temperature damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            pressure_timescale: (float) Pressure damping factor (cf. https://lammps.sandia.gov/doc/fix_nh.html)
-            seed: (int) Seed for the random number generation (required for the velocity creation)
-            tloop:
-            initial_temperature: (None or float) Initial temperature according to which the initial velocity field
-                                 is created. If None, the initial temperature will be twice the target temperature
-                                 (which would go immediately down to the target temperature as described in
-                                 equipartition theorem). If 0, the velocity field is not initialized (in which case
-                                 the initial velocity given in structure will be used). If any other number is given,
-                                 this value is going to be used for the initial temperature.
-            langevin: (True or False) Activate Langevin dynamics
-        """
-        if self.server.run_mode.interactive_non_modal:
-            warnings.warn('calc_md() is not implemented for the non modal interactive mode use calc_static()!')
-        super(LammpsInteractive, self).calc_md(temperature=temperature, pressure=pressure, n_ionic_steps=n_ionic_steps,
-                                               time_step=time_step, n_print=n_print,
-                                               temperature_timescale=temperature_timescale,
-                                               pressure_timescale=pressure_timescale, seed=seed, tloop=tloop,
-                                               initial_temperature=initial_temperature, langevin=langevin,
-                                               delta_temp=delta_temp, delta_press=delta_press)
-
     def run_if_interactive(self):
         if self._generic_input['calc_mode'] == 'md':
             self.input.control['run'] = self._generic_input['n_print']


### PR DESCRIPTION
Rename the thermo(baro)stat strenght variables and set new defaults.

After our extended discussion in the last pyiron_mpie pull request for this branch and again at the dev meeting on Friday, here is a finished version of the new `calc_md` functionality for Lammps calculations. An associated notebook is in the meetings folder.

Once the branch is merged, I'll send an at-all message in Support letting people know about the change and where to find the example notebook.