### PR TITLE
Increase number of cores for the GenericMaster

### DIFF
--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -82,6 +82,7 @@ class InteractiveWrapper(GenericMaster):
             self._ref_job = self.pop(-1)
             if self._job_id is not None and self._ref_job._master_id is None:
                 self._ref_job.master_id = self.job_id
+                self._ref_job.server.cores = self.server.cores
 
     def get_final_structure(self):
         """

--- a/pyiron/base/master/generic.py
+++ b/pyiron/base/master/generic.py
@@ -178,6 +178,8 @@ class GenericMaster(GenericJob):
         Args:
             job (GenericJob): job to append
         """
+        if job.server.cores >= self.server.cores:
+            self.server.cores = job.server.cores
         if job.job_name not in self._job_name_lst:
             self._job_name_lst.append(job.job_name)
             self._child_job_update_hdf(parent_job=self, child_job=job)

--- a/pyiron/base/master/serial.py
+++ b/pyiron/base/master/serial.py
@@ -234,7 +234,9 @@ class SerialMasterBase(GenericMaster):
             return None
         if job_name is None:
             job_name = '_'.join(ham_old.job_name.split('_')[:-1] + [str(len(self.child_ids))])
-        return ham_old.restart(job_name=job_name)
+        new_job = ham_old.restart(job_name=job_name)
+        new_job.server.cores = self.server.cores
+        return new_job
 
     def collect_output(self):
         """


### PR DESCRIPTION
If the number of cores for the child is larger than the number of cores for the master, set the number of cores for the master to the same level as the number of cores for the child.