### PR TITLE
Plot3d colours

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1163,18 +1163,24 @@ class Atoms(object):
             show_cell (bool): Whether or not to show the frame. (Default is True.)
             show_axes (bool): Whether or not to show xyz axes. (Default is True.)
             camera (str): 'perspective' or 'orthographic'. (Default is 'perspective'.)
-            spacefill (bool): Whether to use a space-filling or ball-and-stick representation. (Default is True, use space-filling atoms.)
+            spacefill (bool): Whether to use a space-filling or ball-and-stick representation. (Default is True, use
+                space-filling atoms.)
             particle_size (float): Size of the particles. (Default is 1.)
-            select_atoms (ndarray): Indices of atoms to show, either as integers or a boolean array mask. (Default is None, show all atoms)
+            select_atoms (ndarray): Indices of atoms to show, either as integers or a boolean array mask. (Default is
+                None, show all atoms)
             background (str): Background color. (Default is 'white'.)
             color_scheme (str): NGLView color scheme to use. (Default is None, color by element.)
-            colors (ndarray): A per-atom array of HTML color names or hex color codes to use for atomic colors. (Default is None, use coloring scheme.)
+            colors (ndarray): A per-atom array of HTML color names or hex color codes to use for atomic colors.
+                (Default is None, use coloring scheme.)
             scalar_field (ndarray): Color each atom according to the array value (Default is None, use coloring scheme.)
-            scalar_start (float): The scalar value to be mapped onto the low end of the color map (lower values are clipped). (Default is None, use the minimum value in `scalar_field`.)
-            scalar_end (float): The scalar value to be mapped onto the high end of the color map (higher values are clipped). (Default is None, use the maximum value in `scalar_field`.)
+            scalar_start (float): The scalar value to be mapped onto the low end of the color map (lower values are
+                clipped). (Default is None, use the minimum value in `scalar_field`.)
+            scalar_end (float): The scalar value to be mapped onto the high end of the color map (higher values are
+                clipped). (Default is None, use the maximum value in `scalar_field`.)
             scalar_cmap (matplotlib.cm): The colormap to use. (Default is None, giving a blue-red divergent map.)
             vector_field (ndarray): Add vectors (3 values) originating at each atom. (Default is None, no vectors.)
-            vector_color (ndarray): Colors for the vectors (only available with vector_field). (Default is None, vectors are colored by their direction.)
+            vector_color (ndarray): Colors for the vectors (only available with vector_field). (Default is None,
+                vectors are colored by their direction.)
 
             Possible NGLView color schemes:
               " ", "picking", "random", "uniform", "atomindex", "residueindex",

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1146,7 +1146,6 @@ class Atoms(object):
         """
         return (shift + slope * np.sqrt(atomic_number)) * scale
 
-    
     def plot3d(self, show_cell=True, show_axes=True, camera='perspective', spacefill=True, particle_size=1.0,
                select_atoms=None, background='white', color_scheme=None,
                scalar_field=None, vector_field=None, vector_color=None,

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1253,6 +1253,7 @@ class Atoms(object):
                 shift[n] = 1
                 end = list(start + shift)
                 color = list(shift)
+                # We cast as list to avoid JSON warnings
                 view.shape.add_arrow(start, end, color, arrow_radius)
                 view.shape.add_text(end, text_color, text_size, arrow_names[n])
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1106,11 +1106,11 @@ class Atoms(object):
         Turns structure information into a NGLView-readable protein-database-formatted string.
 
         Args:
-            elements (ndarray/list): Element symbol for each atom.
-            positions (ndarray/list): Vector of Cartesian atom positions.
-            cell (ndarray/list): Simulation cell Bravais matrix.
-            scalar_field (ndarray/list): Per-atom vector of floats used to re-color the atoms. (Default is None, use
-                NGLView coloring scheme.)
+            elements (numpy.ndarray/list): Element symbol for each atom.
+            positions (numpy.ndarray/list): Vector of Cartesian atom positions.
+            cell (numpy.ndarray/list): Simulation cell Bravais matrix.
+            scalar_field (numpy.ndarray/list): Per-atom vector of floats used to re-color the atoms. (Default is None,
+                use NGLView coloring scheme.)
 
         Returns:
             (str): The PDB-formatted representation of the structure.
@@ -1153,8 +1153,8 @@ class Atoms(object):
 
         Args:
             view (NGLWidget): The widget to work on.
-            elements (ndarray/list): Elemental symbols.
-            atomic_numbers (ndarray/list): Integer atomic numbers for determining atomic size.
+            elements (numpy.ndarray/list): Elemental symbols.
+            atomic_numbers (numpy.ndarray/list): Integer atomic numbers for determining atomic size.
             particle_size (float): A scale factor for the atomic size.
             scheme (str): The scheme to use. (Default is "element".)
 
@@ -1179,9 +1179,9 @@ class Atoms(object):
 
         Args:
             view (NGLWidget): The widget to work on.
-            atomic_numbers (ndarray/list): Integer atomic numbers for determining atomic size.
+            atomic_numbers (numpy.ndarray/list): Integer atomic numbers for determining atomic size.
             particle_size (float): A scale factor for the atomic size.
-            colors (ndarray/list): A per-atom list of HTML or hex color codes.
+            colors (numpy.ndarray/list): A per-atom list of HTML or hex color codes.
 
         Returns:
             (NGLWidget): The modified widget.
@@ -1199,7 +1199,7 @@ class Atoms(object):
         Convert scalar values to hex codes using a colormap.
 
         Args:
-            scalar_field (ndarray/list): Scalars to convert.
+            scalar_field (numpy.ndarray/list): Scalars to convert.
             start (float): Scalar value to map to the bottom of the colormap (values below are clipped). (Default is
                 None, use the minimal scalar value.)
             end (float): Scalar value to map to the top of the colormap (values above are clipped).  (Default is
@@ -1244,20 +1244,22 @@ class Atoms(object):
             spacefill (bool): Whether to use a space-filling or ball-and-stick representation. (Default is True, use
                 space-filling atoms.)
             particle_size (float): Size of the particles. (Default is 1.)
-            select_atoms (ndarray): Indices of atoms to show, either as integers or a boolean array mask. (Default is
-                None, show all atoms)
+            select_atoms (numpy.ndarray): Indices of atoms to show, either as integers or a boolean array mask.
+                (Default is None, show all atoms.)
             background (str): Background color. (Default is 'white'.)
             color_scheme (str): NGLView color scheme to use. (Default is None, color by element.)
-            colors (ndarray): A per-atom array of HTML color names or hex color codes to use for atomic colors.
+            colors (numpy.ndarray): A per-atom array of HTML color names or hex color codes to use for atomic colors.
                 (Default is None, use coloring scheme.)
-            scalar_field (ndarray): Color each atom according to the array value (Default is None, use coloring scheme.)
+            scalar_field (numpy.ndarray): Color each atom according to the array value (Default is None, use coloring
+                scheme.)
             scalar_start (float): The scalar value to be mapped onto the low end of the color map (lower values are
                 clipped). (Default is None, use the minimum value in `scalar_field`.)
             scalar_end (float): The scalar value to be mapped onto the high end of the color map (higher values are
                 clipped). (Default is None, use the maximum value in `scalar_field`.)
             scalar_cmap (matplotlib.cm): The colormap to use. (Default is None, giving a blue-red divergent map.)
-            vector_field (ndarray): Add vectors (3 values) originating at each atom. (Default is None, no vectors.)
-            vector_color (ndarray): Colors for the vectors (only available with vector_field). (Default is None,
+            vector_field (numpy.ndarray): Add vectors (3 values) originating at each atom. (Default is None, no
+                vectors.)
+            vector_color (numpy.ndarray): Colors for the vectors (only available with vector_field). (Default is None,
                 vectors are colored by their direction.)
 
             Possible NGLView color schemes:

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1266,6 +1266,7 @@ class Atoms(object):
 
         Warnings:
             * Many features only work with space-filling atoms (e.g. coloring by a scalar field).
+            * The colour interpretation of some hex codes is weird, e.g. 'green'.
         """
         try:  # If the graphical packages are not available, the GUI will not work.
             import nglview

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -11,7 +11,6 @@ import numpy as np
 from six import string_types
 import warnings
 from ase.geometry import cellpar_to_cell, complete_cell
-from seaborn import diverging_palette
 from matplotlib.colors import rgb2hex
 from scipy.interpolate import interp1d
 
@@ -1217,6 +1216,10 @@ class Atoms(object):
         remapped_field = interp(np.clip(scalar_field, start, end))  # Map field onto [0,1]
 
         if cmap is None:
+            try:
+                from seaborn import diverging_palette
+            except ImportError:
+                print("The package seaborn needs to be installed for the plot3d() function!")
             cmap = diverging_palette(245, 15, as_cmap=True)  # A nice blue-red palette
 
         return [rgb2hex(cmap(scalar)[:3]) for scalar in remapped_field]  # The slice gets RGB but leaves alpha

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -11,7 +11,8 @@ import numpy as np
 from six import string_types
 import warnings
 from ase.geometry import cellpar_to_cell, complete_cell
-import seaborn as sns
+from seaborn import diverging_palette
+from matplotlib.colors import rgb2hex
 
 from pyiron.atomistics.structure.atom import Atom
 from pyiron.atomistics.structure.sparse_list import SparseArray, SparseList
@@ -1230,14 +1231,14 @@ class Atoms(object):
             if scalar_field is not None:
                 assert(color_scheme is None)
                 scalar_field = (scalar_field - np.amin(scalar_field)) / np.ptp(scalar_field)  # Map field onto [0,1]
-                cmap = sns.diverging_palette(245, 15, as_cmap=True)
+                cmap = diverging_palette(245, 15, as_cmap=True)
 
                 for n, num in enumerate(atomic_numbers):
-
+                    color = rgb2hex(cmap(scalar_field[n])[:3])  # Map fractional rgb colors (no alpha) to hex
                     view.add_spacefill(selection=[n],
                                        radius_type='vdw',
                                        radius=self._atomic_number_to_radius(num, scale=particle_size),
-                                       color=cmap(scalar_field[n]))
+                                       color=color)
             else:
                 if color_scheme is None:
                     color_scheme = 'element'

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1101,7 +1101,7 @@ class Atoms(object):
         return 'ATOM {:>6} {:>4} {:>4} {:>5} {:10.3f} {:7.3f} {:7.3f} {:5.2f} {:5.2f} {:>11} \n'.format(
             num, species, group, num2, x, y, z, occupancy, temperature_factor, species)
     
-    def _ngl_write_structure(self, elements, positions, cell, scalar_field=None):
+    def _ngl_write_structure(self, elements, positions, cell):
         """
         Turns structure information into a NGLView-readable protein-database-formatted string.
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1058,115 +1058,208 @@ class Atoms(object):
 
     @staticmethod
     def _ngl_write_cell(a1, a2, a3, f1=90, f2=90, f3=90):
+        """
+        Writes a PDB-formatted line to represent the simulation cell.
+
+        Args:
+            a1, a2, a3 (float): Lengths of the cell vectors.
+            f1, f2, f3 (float): Angles between the cell vectors (which angles exactly?) (in degrees).
+
+        Returns:
+            (str): The line defining the cell in PDB format.
+        """
         return 'CRYST1 {:8.3f} {:8.3f} {:8.3f} {:6.2f} {:6.2f} {:6.2f} P 1\n'.format(a1, a2, a3, f1, f2, f3)
     
     @staticmethod
-    def _ngl_write_atom(num, species, group, num2, coords=None, c0=None, c1=None):
+    def _ngl_write_atom(num, species, group, num2, coords=None, occupancy=None, temperature_factor=None):
+        """
+        Writes a PDB-formatted line to represent an atom.
+
+        Args:
+            num (int): Atomic index.
+            species (str): Elemental species.
+            group (str):
+            num2 (int): An "alternate" index. (Don't ask me...)
+            coords (list/ndarray[float]: X, Y, and Z coordinates of the atom.
+            occupancy (float): PDB occupancy parameter.
+            temperature_factor (float): PDB temperature factor parameter.
+
+        Returns:
+            (str): The line defining an atom in PDB format
+
+        Warnings:
+            * The [PDB docs](https://www.cgl.ucsf.edu/chimera/docs/UsersGuide/tutorials/pdbintro.html) indicate that
+                the xyz coordinates might need to be in some sort of orthogonal basis. If you have weird behaviour,
+                this might be a good place to investigate.
+        """
         x, y, z = coords
-        return 'ATOM {:>6} {:>4} {:>4} {:>5} {:10.3f} {:7.3f} {:7.3f} {:5.2f} {:5.2f} {:>11} \n'.format(num, species, group, num2, x, y, z, c0, c1, species)
+        return 'ATOM {:>6} {:>4} {:>4} {:>5} {:10.3f} {:7.3f} {:7.3f} {:5.2f} {:5.2f} {:>11} \n'.format(
+            num, species, group, num2, x, y, z, occupancy, temperature_factor, species)
     
     def _ngl_write_structure(self, elements, positions, cell, scalar_field=None):
+        """
+        Turns structure information into a NGLView-readable protein-database-formatted string.
+
+        Args:
+            elements (ndarray/list): Element symbol for each atom.
+            positions (ndarray/list): Vector of Cartesian atom positions.
+            cell (ndarray/list): Simulation cell Bravais matrix.
+            scalar_field (ndarray/list): Per-atom vector of floats used to re-color the atoms. (Default is None, use
+                NGLView coloring scheme.)
+
+        Returns:
+            (str): The PDB-formatted representation of the structure.
+        """
         from ase.geometry import cell_to_cellpar, cellpar_to_cell
         cellpar = cell_to_cellpar(cell)
         exportedcell = cellpar_to_cell(cellpar)
         rotation = np.linalg.solve(cell, exportedcell)
   
-        pdb_str = self._ngl_write_cell(cellpar[0], cellpar[1], cellpar[2], cellpar[3], cellpar[4], cellpar[5])
+        pdb_str = self._ngl_write_cell(*cellpar)
         pdb_str += 'MODEL     1\n'
+
         if scalar_field is None:
             scalar_field = np.ones(len(positions))
         else:
-            scalar_field = (scalar_field-np.min(scalar_field))/(np.max(scalar_field)-np.min(scalar_field))
+            scalar_field = (scalar_field - np.amin(scalar_field)) / np.ptp(scalar_field)
+
         for i, p in enumerate(positions):
             if rotation is not None:
                 p = p.dot(rotation)
                 
-            pdb_str += self._ngl_write_atom(i, elements[i], group=elements[i], num2=i, coords=p, c0=scalar_field[i], c1=0.0)
+            pdb_str += self._ngl_write_atom(i, elements[i],
+                                            group=elements[i],
+                                            num2=i,
+                                            coords=p,
+                                            occupancy=scalar_field[i],
+                                            temperature_factor=0.0)
         pdb_str += 'ENDMDL \n'
         return pdb_str
     
-    def plot3d(self, spacefill=True, show_cell=True, camera='perspective', particle_size=1.0,
-               background='white', color_scheme=None, show_axes=True, custom_array=None, custom_3darray=None,
-               scalar_field=None, vector_field=None, vector_color=None, select_atoms=None):
+    def plot3d(self, show_cell=True, show_axes=True, camera='perspective', spacefill=True, particle_size=1.0,
+               select_atoms=None, background='white', color_scheme=None,
+               scalar_field=None, vector_field=None, vector_color=None,
+               custom_array=None, custom_3darray=None):
         """
+        Plot3d relies on NGLView to visualize atomic structures. Here, we construct a string in the "protein database"
+        ("pdb") format, then turn it into an NGLView "structure". PDB is a white-space sensitive format, so the
+        string snippets are carefully formatted.
+
+        The final widget is returned. If it is assigned to a variable, the visualization is suppressed until that
+        variable is evaluated, and in the meantime more NGL operations can be applied to it to modify the visualization.
 
         Args:
-            spacefill:
-            show_cell: whether to show the frame or not (default: True)
-            camera: 'perspective' or 'orthographic'
-            particle_size: particle size
-            background: back ground color
-            color_scheme: v.i.
-            scalar_field: color for each atom according to the array value
-            vector_field: vectors for each atom according to the array values (3 values for each atom)
-            vector_color: vector for color coding (only available with vector_field)
-            select_atoms: atoms to show (1d array with ID's or True for atoms to show)
+            show_cell (bool): Whether or not to show the frame. (Default is True.)
+            show_axes (bool): Whether or not to show xyz axes. (Default is True.)
+            camera (str): 'perspective' or 'orthographic'. (Default is 'perspective'.)
+            spacefill (bool): Whether to use a space-filling or ball-and-stick representation. (Default is True, use space-filling atoms.)
+            particle_size (float): Size of the particles. (Default is 1.)
+            select_atoms (ndarray): Indices of atoms to show, either as integers or a boolean array mask. (Default is None, show all atoms)
+            background (str): Background color. (Default is 'white'.)
+            color_scheme (str): NGLView color scheme to use. (Default is None,
+            scalar_field (ndarray): Color each atom according to the array value (Default is None, use coloring scheme.)
+            vector_field (ndarray): Add vectors (3 values) originating at each atom. (Default is None, no vectors.)
+            vector_color (ndarray): Colors for the vectors (only available with vector_field). (Default is None, vectors are colored by their direction.)
 
-            Possible color schemes: 
+            Possible NGLView color schemes:
               " ", "picking", "random", "uniform", "atomindex", "residueindex",
               "chainindex", "modelindex", "sstruc", "element", "resname", "bfactor",
               "hydrophobicity", "value", "volume", "occupancy"
     
         Returns:
-    
+            (NGLWidget): The NGLView widget itself, which can be operated on further or viewed as-is.
         """
         try:  # If the graphical packages are not available, the GUI will not work.
             import nglview
         except ImportError:
             raise ImportError("The package nglview needs to be installed for the plot3d() function!")
+
         if custom_array is not None:
             warnings.warn('custom_array is deprecated. Use scalar_field instead', DeprecationWarning)
             scalar_field = custom_array
+
         if custom_3darray is not None:
             warnings.warn('custom_3darray is deprecated. Use vector_field instead', DeprecationWarning)
             vector_field = custom_3darray
-        # Always visualize the parent basis
+
         parent_basis = self.get_parent_basis()
-        if select_atoms is None:
-            select_atoms = np.array(len(parent_basis)*[True])
-        else:
-            select_atoms = np.array(select_atoms)
+        elements = parent_basis.get_chemical_symbols()
+        positions = self.positions
+
+        # If `select_atoms` was given, visualize only a subset of the `parent_basis`
+        if select_atoms is not None:
+            select_atoms = np.array(select_atoms, dtype=int)
+            elements = elements[select_atoms]
+            positions = positions[select_atoms]
             if scalar_field is not None:
                 scalar_field = scalar_field[select_atoms]
-        struct = nglview.TextStructure(self._ngl_write_structure(parent_basis.get_chemical_symbols()[select_atoms],
-                                                                 self.positions[select_atoms], self.cell, scalar_field=scalar_field))
+            if vector_field is not None:
+                vector_field = vector_field[select_atoms]
+            if vector_color is not None:
+                vector_color = vector_color[select_atoms]
+
+        # Write the nglview protein-database-formatted string
+        struct = nglview.TextStructure(self._ngl_write_structure(elements,
+                                                                 positions,
+                                                                 self.cell,
+                                                                 scalar_field=scalar_field))
+        # Parse the string into the displayable widget
         view = nglview.NGLWidget(struct)
+
         if spacefill:
             if color_scheme is None and scalar_field is not None:
                 color_scheme = 'occupancy'
             elif color_scheme is None:
                 color_scheme = 'element'
-            #view.add_spacefill(radius_type='vdw', color_scheme=color_scheme, radius=particle_size)
+            # TODO: Raise a warning if `color_scheme` and `scalar_field` are both given.
+
             for elem, num in set(list(zip(parent_basis.get_chemical_symbols(), parent_basis.get_atomic_numbers()))):
-                view.add_spacefill(selection='#'+elem, radius_type='vdw', color_scheme=color_scheme, radius=particle_size*(0.2+0.1*np.sqrt(num)))
-            # view.add_spacefill(radius=1.0)
+                view.add_spacefill(selection='#'+elem,
+                                   radius_type='vdw',
+                                   color_scheme=color_scheme,
+                                   radius=particle_size * (0.2 + 0.1 * np.sqrt(num)))
+
             view.remove_ball_and_stick()
         else:
             view.add_ball_and_stick()
+
         if show_cell:
             if parent_basis.cell is not None:
                 view.add_unitcell()
+
         if vector_color is None and vector_field is not None:
-            vector_color = 0.5*vector_field/np.linalg.norm(vector_field, axis=-1)[:, np.newaxis]+0.5
-        elif vector_field is not None and vector_field is not None:
+            vector_color = 0.5 * vector_field / np.linalg.norm(vector_field, axis=-1)[:, np.newaxis] + 0.5
+        elif vector_field is not None and vector_field is not None:  # WARNING: There must be a bug here...
             try:
                 if vector_color.shape != np.ones((len(self), 3)).shape:
-                    vector_color = np.outer(np.ones(len(self)), vector_color/np.linalg.norm(vector_color))
+                    vector_color = np.outer(np.ones(len(self)), vector_color / np.linalg.norm(vector_color))
             except AttributeError:
-                vector_color = np.ones((len(self), 3))*vector_color
+                vector_color = np.ones((len(self), 3)) * vector_color
+
         if vector_field is not None:
-            for arr, pos, col in zip(vector_field[select_atoms], self.positions[select_atoms], vector_color[select_atoms]):
-                view.shape.add_arrow(list(pos), list(pos+arr), list(col), 0.2)
-        if show_axes:
+            for arr, pos, col in zip(vector_field, positions, vector_color):
+                view.shape.add_arrow(list(pos), list(pos + arr), list(col), 0.2)
+
+        if show_axes:  # Add axes
             axes_origin = -np.ones(3)
-            view.shape.add_arrow(list(axes_origin), list(axes_origin+np.array([1, 0, 0])), [1, 0, 0], 0.1)
-            view.shape.add_arrow(list(axes_origin), list(axes_origin+np.array([0, 1, 0])), [0, 1, 0], 0.1)
-            view.shape.add_arrow(list(axes_origin), list(axes_origin+np.array([0, 0, 1])), [0, 0, 1], 0.1)
-            view.shape.add_text(list(axes_origin+np.array([0, 0, 1])), [0, 0, 0], 1, 'z')
-            view.shape.add_text(list(axes_origin+np.array([0, 1, 0])), [0, 0, 0], 1, 'y')
-            view.shape.add_text(list(axes_origin+np.array([1, 0, 0])), [0, 0, 0], 1, 'x')
-        if camera!='perspective' and camera!='orthographic':
+            arrow_radius = 0.1
+            text_size = 1
+            text_color = [0, 0, 0]
+            arrow_names = ['x', 'y', 'z']
+
+            for n in [0, 1, 2]:
+                start = axes_origin
+                shift = np.zeros(3)
+                shift[n] = 1
+                end = start + shift
+                color = list(shift)
+                # WARNING: Start and end were previously cast explicitly as lists; if you get an error check this.
+                view.shape.add_arrow(start, end, color, arrow_radius)
+                view.shape.add_text(end, text_color, text_size, arrow_names[n])
+
+        if camera != 'perspective' and camera != 'orthographic':
             warnings.warn('Only perspective or orthographic is (likely to be) permitted for camera')
+
         view.camera = camera
         view.background = background
         return view

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1194,19 +1194,25 @@ class Atoms(object):
         return view
 
     @staticmethod
-    def _scalars_to_hex_colors(scalar_field, start, end, cmap=None):
+    def _scalars_to_hex_colors(scalar_field, start=None, end=None, cmap=None):
         """
         Convert scalar values to hex codes using a colormap.
 
         Args:
             scalar_field (ndarray/list): Scalars to convert.
-            start (float): Scalar value to map to the bottom of the colormap (values below are clipped).
-            end (float): Scalar value to map to the top of the colormap (values above are clipped).
+            start (float): Scalar value to map to the bottom of the colormap (values below are clipped). (Default is
+                None, use the minimal scalar value.)
+            end (float): Scalar value to map to the top of the colormap (values above are clipped).  (Default is
+                None, use the maximal scalar value.)
             cmap (matplotlib.cm): The colormap to use. (Default is None, which gives a blue-red divergent map.)
 
         Returns:
             (list): The corresponding hex codes for each scalar value passed in.
         """
+        if start is None:
+            start = np.amin(scalar_field)
+        if end is None:
+            end = np.amax(scalar_field)
         interp = interp1d([start, end], [0, 1])
         remapped_field = interp(np.clip(scalar_field, start, end))  # Map field onto [0,1]
 
@@ -1291,10 +1297,6 @@ class Atoms(object):
             if scalar_field is not None:
                 scalar_field = np.array(scalar_field)
                 scalar_field = scalar_field[select_atoms]
-                if scalar_start is None:
-                    scalar_start = np.amin(scalar_field)
-                if scalar_end is None:
-                    scalar_end = np.amax(scalar_field)
             if vector_field is not None:
                 vector_field = np.array(vector_field)
                 vector_field = vector_field[select_atoms]
@@ -1320,7 +1322,6 @@ class Atoms(object):
                 view = self._add_custom_color_spacefill(view, atomic_numbers, particle_size, colors)
             # Color by per-atom scalars
             elif scalar_field is not None:  # Color by per-atom scalars
-                print("sstart/end", scalar_start, scalar_end)
                 colors = self._scalars_to_hex_colors(scalar_field, scalar_start, scalar_end, scalar_cmap)
                 view = self._add_custom_color_spacefill(view, atomic_numbers, particle_size, colors)
             # Color by element

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1248,12 +1248,11 @@ class Atoms(object):
             arrow_names = ['x', 'y', 'z']
 
             for n in [0, 1, 2]:
-                start = axes_origin
+                start = list(axes_origin)
                 shift = np.zeros(3)
                 shift[n] = 1
-                end = start + shift
+                end = list(start + shift)
                 color = list(shift)
-                # WARNING: Start and end were previously cast explicitly as lists; if you get an error check this.
                 view.shape.add_arrow(start, end, color, arrow_radius)
                 view.shape.add_text(end, text_color, text_size, arrow_names[n])
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1320,6 +1320,7 @@ class Atoms(object):
                 view = self._add_custom_color_spacefill(view, atomic_numbers, particle_size, colors)
             # Color by per-atom scalars
             elif scalar_field is not None:  # Color by per-atom scalars
+                print("sstart/end", scalar_start, scalar_end)
                 colors = self._scalars_to_hex_colors(scalar_field, scalar_start, scalar_end, scalar_cmap)
                 view = self._add_custom_color_spacefill(view, atomic_numbers, particle_size, colors)
             # Color by element

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1147,7 +1147,7 @@ class Atoms(object):
         """
         return (shift + slope * np.sqrt(atomic_number)) * scale
 
-    def _add_colorscheme_spacefill(self, view, elements, atomic_numbers, particle_size, scheme='elements'):
+    def _add_colorscheme_spacefill(self, view, elements, atomic_numbers, particle_size, scheme='element'):
         """
         Set NGLView spacefill parameters according to a color-scheme.
 
@@ -1217,8 +1217,8 @@ class Atoms(object):
 
     def plot3d(self, show_cell=True, show_axes=True, camera='perspective', spacefill=True, particle_size=1.0,
                select_atoms=None, background='white', color_scheme=None, colors=None,
-               scalar_field=None, scalar_start=None, scalar_end=None, scalar_cmap=None, vector_field=None, vector_color=None,
-               custom_array=None, custom_3darray=None):
+               scalar_field=None, scalar_start=None, scalar_end=None, scalar_cmap=None,
+               vector_field=None, vector_color=None, custom_array=None, custom_3darray=None):
         """
         Plot3d relies on NGLView to visualize atomic structures. Here, we construct a string in the "protein database"
         ("pdb") format, then turn it into an NGLView "structure". PDB is a white-space sensitive format, so the

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1227,13 +1227,13 @@ class Atoms(object):
         view = nglview.NGLWidget(struct)
 
         if spacefill:
-            elemental_data_list = list(zip(elements, atomic_numbers))
-
             if scalar_field is not None:
                 assert(color_scheme is None)
                 scalar_field = (scalar_field - np.amin(scalar_field)) / np.ptp(scalar_field)  # Map field onto [0,1]
                 cmap = sns.diverging_palette(245, 15, as_cmap=True)
-                for n, elem, num, in enumerate(elemental_data_list):
+
+                for n, num in enumerate(atomic_numbers):
+
                     view.add_spacefill(selection=[n],
                                        radius_type='vdw',
                                        radius=self._atomic_number_to_radius(num, scale=particle_size),
@@ -1242,7 +1242,7 @@ class Atoms(object):
                 if color_scheme is None:
                     color_scheme = 'element'
 
-                for elem, num in set(elemental_data_list):
+                for elem, num in set(list(zip(elements, atomic_numbers))):
                     view.add_spacefill(selection='#' + elem,
                                        radius_type='vdw',
                                        radius=self._atomic_number_to_radius(num, scale=particle_size),

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1217,10 +1217,8 @@ class Atoms(object):
                 vector_color = vector_color[select_atoms]
 
         # Write the nglview protein-database-formatted string
-        struct = nglview.TextStructure(self._ngl_write_structure(elements,
-                                                                 positions,
-                                                                 self.cell,
-                                                                 scalar_field=scalar_field))
+        struct = nglview.TextStructure(self._ngl_write_structure(elements, positions, self.cell))
+
         # Parse the string into the displayable widget
         view = nglview.NGLWidget(struct)
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1148,6 +1148,24 @@ class Atoms(object):
         return (shift + slope * np.sqrt(atomic_number)) * scale
 
     def _add_colorscheme_spacefill(self, view, elements, atomic_numbers, particle_size, scheme='elements'):
+        """
+        Set NGLView spacefill parameters according to a color-scheme.
+
+        Args:
+            view (NGLWidget): The widget to work on.
+            elements (ndarray/list): Elemental symbols.
+            atomic_numbers (ndarray/list): Integer atomic numbers for determining atomic size.
+            particle_size (float): A scale factor for the atomic size.
+            scheme (str): The scheme to use. (Default is "element".)
+
+            Possible NGLView color schemes:
+              " ", "picking", "random", "uniform", "atomindex", "residueindex",
+              "chainindex", "modelindex", "sstruc", "element", "resname", "bfactor",
+              "hydrophobicity", "value", "volume", "occupancy"
+
+        Returns:
+            (NGLWidget): The modified widget.
+        """
         for elem, num in set(list(zip(elements, atomic_numbers))):
             view.add_spacefill(selection='#' + elem,
                                radius_type='vdw',
@@ -1156,6 +1174,18 @@ class Atoms(object):
         return view
 
     def _add_custom_color_spacefill(self, view, atomic_numbers, particle_size, colors):
+        """
+        Set NGLView spacefill parameters according to per-atom colors.
+
+        Args:
+            view (NGLWidget): The widget to work on.
+            atomic_numbers (ndarray/list): Integer atomic numbers for determining atomic size.
+            particle_size (float): A scale factor for the atomic size.
+            colors (ndarray/list): A per-atom list of HTML or hex color codes.
+
+        Returns:
+            (NGLWidget): The modified widget.
+        """
         for n, num in enumerate(atomic_numbers):
             view.add_spacefill(selection=[n],
                                radius_type='vdw',
@@ -1165,6 +1195,18 @@ class Atoms(object):
 
     @staticmethod
     def _scalars_to_hex_colors(scalar_field, start, end, cmap=None):
+        """
+        Convert scalar values to hex codes using a colormap.
+
+        Args:
+            scalar_field (ndarray/list): Scalars to convert.
+            start (float): Scalar value to map to the bottom of the colormap (values below are clipped).
+            end (float): Scalar value to map to the top of the colormap (values above are clipped).
+            cmap (matplotlib.cm): The colormap to use. (Default is None, which gives a blue-red divergent map.)
+
+        Returns:
+            (list): The corresponding hex codes for each scalar value passed in.
+        """
         interp = interp1d([start, end], [0, 1])
         remapped_field = interp(np.clip(scalar_field, start, end))  # Map field onto [0,1]
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1073,18 +1073,18 @@ class Atoms(object):
         return 'CRYST1 {:8.3f} {:8.3f} {:8.3f} {:6.2f} {:6.2f} {:6.2f} P 1\n'.format(a1, a2, a3, f1, f2, f3)
     
     @staticmethod
-    def _ngl_write_atom(num, species, group, num2, coords=None, occupancy=None, temperature_factor=None):
+    def _ngl_write_atom(num, species, x, y, z, group=None, num2=None, occupancy=1., temperature_factor=0.):
         """
         Writes a PDB-formatted line to represent an atom.
 
         Args:
             num (int): Atomic index.
             species (str): Elemental species.
-            group (str):
-            num2 (int): An "alternate" index. (Don't ask me...)
-            coords (list/ndarray[float]: X, Y, and Z coordinates of the atom.
-            occupancy (float): PDB occupancy parameter.
-            temperature_factor (float): PDB temperature factor parameter.
+            x, y, z (float): Cartesian coordinates of the atom.
+            group (str): A...group name? (Default is None, repeat elemental species.)
+            num2 (int): An "alternate" index. (Don't ask me...) (Default is None, repeat first number.)
+            occupancy (float): PDB occupancy parameter. (Default is 1.)
+            temperature_factor (float): PDB temperature factor parameter. (Default is 0.
 
         Returns:
             (str): The line defining an atom in PDB format
@@ -1094,7 +1094,10 @@ class Atoms(object):
                 the xyz coordinates might need to be in some sort of orthogonal basis. If you have weird behaviour,
                 this might be a good place to investigate.
         """
-        x, y, z = coords
+        if group is None:
+            group = species
+        if num2 is None:
+            num2 = num
         return 'ATOM {:>6} {:>4} {:>4} {:>5} {:10.3f} {:7.3f} {:7.3f} {:5.2f} {:5.2f} {:>11} \n'.format(
             num, species, group, num2, x, y, z, occupancy, temperature_factor, species)
     
@@ -1123,13 +1126,8 @@ class Atoms(object):
         for i, p in enumerate(positions):
             if rotation is not None:
                 p = p.dot(rotation)
-                
-            pdb_str += self._ngl_write_atom(i, elements[i],
-                                            group=elements[i],
-                                            num2=i,
-                                            coords=p,
-                                            occupancy=1.0,
-                                            temperature_factor=0.0)
+            pdb_str += self._ngl_write_atom(i, elements[i], *p)
+
         pdb_str += 'ENDMDL \n'
         return pdb_str
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1123,9 +1123,10 @@ class Atoms(object):
         pdb_str = self._ngl_write_cell(*cellpar)
         pdb_str += 'MODEL     1\n'
 
+        if rotation is not None:
+            positions = np.array(positions).dot(rotation)
+
         for i, p in enumerate(positions):
-            if rotation is not None:
-                p = p.dot(rotation)
             pdb_str += self._ngl_write_atom(i, elements[i], *p)
 
         pdb_str += 'ENDMDL \n'

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1318,12 +1318,15 @@ class Atoms(object):
         if spacefill:
             # Color by scheme
             if color_scheme is not None:
-                assert(colors is None)
-                assert(scalar_field is None)
+                if colors is not None:
+                    warnings.warn('`color_scheme` is overriding `colors`')
+                if scalar_field is not None:
+                    warnings.warn('`color_scheme` is overriding `scalar_field`')
                 view = self._add_colorscheme_spacefill(view, elements, atomic_numbers, particle_size, color_scheme)
             # Color by per-atom colors
             elif colors is not None:
-                assert(scalar_field is None)
+                if scalar_field is not None:
+                    warnings.warn('`colors` is overriding `scalar_field`')
                 view = self._add_custom_color_spacefill(view, atomic_numbers, particle_size, colors)
             # Color by per-atom scalars
             elif scalar_field is not None:  # Color by per-atom scalars

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1220,7 +1220,7 @@ class Atoms(object):
             # TODO: Raise a warning if `color_scheme` and `scalar_field` are both given.
 
             for elem, num in set(list(zip(parent_basis.get_chemical_symbols(), parent_basis.get_atomic_numbers()))):
-                view.add_spacefill(selection='#'+elem,
+                view.add_spacefill(selection='#' + elem,
                                    radius_type='vdw',
                                    color_scheme=color_scheme,
                                    radius=particle_size * (0.2 + 0.1 * np.sqrt(num)))

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1168,6 +1168,9 @@ class Atoms(object):
     
         Returns:
             (NGLWidget): The NGLView widget itself, which can be operated on further or viewed as-is.
+
+        Warnings:
+            * Many features only work with space-filling atoms (e.g. coloring by a scalar field).
         """
         try:  # If the graphical packages are not available, the GUI will not work.
             import nglview

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1192,10 +1192,13 @@ class Atoms(object):
             elements = elements[select_atoms]
             positions = positions[select_atoms]
             if scalar_field is not None:
+                scalar_field = np.array(scalar_field)
                 scalar_field = scalar_field[select_atoms]
             if vector_field is not None:
+                vector_field = np.array(vector_field)
                 vector_field = vector_field[select_atoms]
             if vector_color is not None:
+                vector_color = np.array(vector_color)
                 vector_color = vector_color[select_atoms]
 
         # Write the nglview protein-database-formatted string

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1109,8 +1109,6 @@ class Atoms(object):
             elements (numpy.ndarray/list): Element symbol for each atom.
             positions (numpy.ndarray/list): Vector of Cartesian atom positions.
             cell (numpy.ndarray/list): Simulation cell Bravais matrix.
-            scalar_field (numpy.ndarray/list): Per-atom vector of floats used to re-color the atoms. (Default is None,
-                use NGLView coloring scheme.)
 
         Returns:
             (str): The PDB-formatted representation of the structure.
@@ -1164,7 +1162,7 @@ class Atoms(object):
               "hydrophobicity", "value", "volume", "occupancy"
 
         Returns:
-            (NGLWidget): The modified widget.
+            (nglview.NGLWidget): The modified widget.
         """
         for elem, num in set(list(zip(elements, atomic_numbers))):
             view.add_spacefill(selection='#' + elem,
@@ -1184,7 +1182,7 @@ class Atoms(object):
             colors (numpy.ndarray/list): A per-atom list of HTML or hex color codes.
 
         Returns:
-            (NGLWidget): The modified widget.
+            (nglview.NGLWidget): The modified widget.
         """
         for n, num in enumerate(atomic_numbers):
             view.add_spacefill(selection=[n],
@@ -1268,7 +1266,7 @@ class Atoms(object):
               "hydrophobicity", "value", "volume", "occupancy"
     
         Returns:
-            (NGLWidget): The NGLView widget itself, which can be operated on further or viewed as-is.
+            (nglview.NGLWidget): The NGLView widget itself, which can be operated on further or viewed as-is.
 
         Warnings:
             * Many features only work with space-filling atoms (e.g. coloring by a scalar field).


### PR DESCRIPTION
Modifications `plot3d` colouring capability.

- Colouring by the scalar field now lets the user define a colourmap (default is blue-red divergent) and limits for which scalars should be mapped to the extrema of the colourmap.
- An explicit per-atom list of colours can also be given (HTML names or hex codes (sort of...some colours come out wrong)). 
- The rest of the functionality (e.g. vector colouring, axes, etc.) should be the same, but I did make code modifications for streamlining and readability.
- Docstrings everywhere.