### PR TITLE
ref_job gives a warning if the job is not set to interactive

### DIFF
--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -65,6 +65,8 @@ class InteractiveWrapper(GenericMaster):
         Args:
             ref_job (GenericJob): reference job
         """
+        if not ref_job.server.run_mode.interactive:
+            warnings.warn("Run mode of the reference job not set to interactive")
         self.append(ref_job)
 
     def validate_ready_to_run(self):


### PR DESCRIPTION
As discussed [here](https://gitlab.mpcdf.mpg.de/pyiron/pyiron-support/issues/137)