### PR TITLE
lammps input corrected

### DIFF
--- a/pyiron/atomistics/master/phonopy.py
+++ b/pyiron/atomistics/master/phonopy.py
@@ -117,7 +117,16 @@ class PhonopyJob(AtomisticParallelMaster):
 
         self.phonopy = None
         self._job_generator = PhonopyJobGenerator(self)
+        self._disable_phonopy_pickle = False
         s.publication_add(phonopy_publication())
+
+    @property
+    def phonopy_pickling_disabled(self):
+        return self._disable_phonopy_pickle
+
+    @phonopy_pickling_disabled.setter
+    def phonopy_pickling_disabled(self, disable):
+        self._disable_phonopy_pickle = disable
 
     @property
     def _phonopy_unit_cell(self):
@@ -170,7 +179,7 @@ class PhonopyJob(AtomisticParallelMaster):
             group_name (str): HDF5 subgroup name - optional
         """
         super(PhonopyJob, self).to_hdf(hdf=hdf, group_name=group_name)
-        if self.phonopy is not None:
+        if self.phonopy is not None and not self._disable_phonopy_pickle:
             with self.project_hdf5.open("output") as hdf5_output:
                 hdf5_output['phonopy_pickeled'] = codecs.encode(pickle.dumps(self.phonopy), "base64").decode()
 

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -545,6 +545,7 @@ class GenericParameters(PyironObject):
             else:
                 v_str = str(v)
 
+            par = ' '.join(par.split(self.multi_word_separator))
             if par == "Comment":
                 string_lst.append(str(v) + self.end_value_char + "\n")
             elif c.strip() == '':
@@ -573,7 +574,6 @@ class GenericParameters(PyironObject):
 
         with open(file_name, 'w') as f:
             for line in self.get_string_lst():
-                line = line.replace(self.multi_word_separator, ' ')
                 f.write(line)
 
     def __repr__(self):
@@ -785,7 +785,7 @@ class GenericParameters(PyironObject):
             bool: [True/False]
         """
         for key, val in self._block_dict.items():
-            par_first = parameter_name.split()[0]
+            par_first = parameter_name.split()[0].split(self.multi_word_separator)[0]
             if par_first in val:
                 parameter_found_in_block = True
                 i_last_block_line = max(self._block_line_dict[key])
@@ -807,6 +807,7 @@ class GenericParameters(PyironObject):
         for par, val in qwargs.items():
             if par in self._dataset["Parameter"]:
                 raise ValueError("Parameter exists already: " + par)
+
             if self._block_dict is not None:
                 self._refresh_block_line_hash_table()
                 if self._append_line_in_block(par, val):

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -573,7 +573,7 @@ class GenericParameters(PyironObject):
 
         with open(file_name, 'w') as f:
             for line in self.get_string_lst():
-                line.replace(self.multi_word_separator, ' ')
+                line = line.replace(self.multi_word_separator, ' ')
                 f.write(line)
 
     def __repr__(self):

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -88,7 +88,7 @@ class GenericParameters(PyironObject):
         self._end_value_char = None
         self._replace_char_dict = None
         self._block_dict = None
-        self._bool_dict = {True: "TRUE", False: "FALSE"}
+        self._bool_dict = {True: "True", False: "False"}
         self._dataset = OrderedDict()
         self._block_line_dict = {}
         self.end_value_char = end_value_char

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -355,6 +355,8 @@ class GenericParameters(PyironObject):
                 val_v = eval(val)
             except (TypeError, NameError, SyntaxError):
                 val_v = val
+            if callable(val_v):
+                val_v = val
             return val_v
         elif default_value is not None:
             return default_value

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -397,11 +397,7 @@ class GenericParameters(PyironObject):
             modify_dict = {k + separator: v for k, v in modify_dict.items()}
 
         for key, val in modify_dict.items():
-            if self._is_multi_word_parameter(key):
-                key_split = " ".join(key.split(self.multi_word_separator))
-                i_key, multi_word_lst = self._find_line(key_split)
-            else:
-                i_key, multi_word_lst = self._find_line(key)
+            i_key, multi_word_lst = self._find_line(key)
 
             if i_key == -1:
                 if append_if_not_present:
@@ -577,6 +573,7 @@ class GenericParameters(PyironObject):
 
         with open(file_name, 'w') as f:
             for line in self.get_string_lst():
+                line.replace(self.multi_word_separator, ' ')
                 f.write(line)
 
     def __repr__(self):
@@ -810,23 +807,10 @@ class GenericParameters(PyironObject):
         for par, val in qwargs.items():
             if par in self._dataset["Parameter"]:
                 raise ValueError("Parameter exists already: " + par)
-
-            if self._is_multi_word_parameter(par):
-                key_lst = par.split(self.multi_word_separator)
-                par = key_lst[0]
-                val = " ".join(key_lst[1:]) + " " + str(val)
-
             if self._block_dict is not None:
                 self._refresh_block_line_hash_table()
                 if self._append_line_in_block(par, val):
                     continue
-
-            for col in self._dataset:
-                self._dataset[col] = np.array(self._dataset[col]).tolist()
-            if self._is_multi_word_parameter(par):
-                key_lst = par.split(self.multi_word_separator)
-                par = key_lst[0]
-                val = " ".join(key_lst[1:]) + " " + str(val)
 
             for col in self._dataset:
                 self._dataset[col] = np.array(self._dataset[col]).tolist()

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -537,9 +537,12 @@ class GenericParameters(PyironObject):
 
         string_lst = []
         if self.val_only:
-            value_lst = tab_dict["Values"]
+            value_lst = tab_dict["Value"]
         else:
-            value_lst = [self[p] for p in tab_dict["Parameter"]]
+            try:
+                value_lst = [self[p] for p in tab_dict["Parameter"]]
+            except ValueError:
+                value_lst = tab_dict["Value"]
         for par, v, c in zip(tab_dict["Parameter"], value_lst, tab_dict["Comment"]):
             # special treatment for values that are bool or str
             if isinstance(v, bool):

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -536,7 +536,11 @@ class GenericParameters(PyironObject):
             tab_dict["Parameter"] = ["" for _ in tab_dict["Value"]]
 
         string_lst = []
-        for par, v, c in zip(tab_dict["Parameter"], tab_dict["Value"], tab_dict["Comment"]):
+        if self.val_only:
+            value_lst = tab_dict["Values"]
+        else:
+            value_lst = [self[p] for p in tab_dict["Parameter"]]
+        for par, v, c in zip(tab_dict["Parameter"], value_lst, tab_dict["Comment"]):
             # special treatment for values that are bool or str
             if isinstance(v, bool):
                 v_str = self._bool_dict[v]

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -47,20 +47,20 @@ class LammpsControl(GenericParameters):
 
     def load_default(self, file_content=None):
         if file_content is None:
-            file_content = ('units         metal\n'+
-                            'dimension     3\n'+
-                            'boundary      p p p\n'+
-                            'atom_style    atomic\n'+
-                            'read_data     structure.inp\n'+
-                            'include       potential.inp\n'+
-                            'fix           ensemble all nve\n'+
-                            'variable      dumptime equal 100\n'+
-                            'dump          1 all custom ${dumptime} dump.out id type xsu ysu zsu fx fy fz\n'+
-                            'dump_modify   1 sort id format line "%d %d %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g"\n'+
-                            'thermo_style  custom step temp pe etotal pxx pxy pxz pyy pyz pzz vol\n'+
-                            'thermo_modify format  float %20.15g\n'+
-                            'thermo        100\n'+
-                            'run           0\n')
+            file_content = ('units               metal\n'+
+                            'dimension           3\n'+
+                            'boundary            p p p\n'+
+                            'atom_style          atomic\n'+
+                            'read_data           structure.inp\n'+
+                            'include             potential.inp\n'+
+                            'fix___ensemble      all nve\n'+
+                            'variable___dumptime equal 100\n'+
+                            'dump___1            all custom ${dumptime} dump.out id type xsu ysu zsu fx fy fz\n'+
+                            'dump_modify___1     sort id format line "%d %d %20.15g %20.15g %20.15g %20.15g %20.15g %20.15g"\n'+
+                            'thermo_style        custom step temp pe etotal pxx pxy pxz pyy pyz pzz vol\n'+
+                            'thermo_modify       format float %20.15g\n'+
+                            'thermo              100\n'+
+                            'run                 0\n')
         self.load_string(file_content)
 
     def calc_minimize(self, e_tol=0.0, f_tol=1e-8, max_iter=100000, pressure=None, n_print=100):
@@ -78,10 +78,10 @@ class LammpsControl(GenericParameters):
                 str_press += ' couple none'
             self.set(fix___ensemble=r'all box/relax' + str_press)
         else:
-            self.remove_keys(["fix"])
+            self.remove_keys(["fix___nve"])
         self.set(minimize=str(e_tol) + ' ' + str(f_tol) + ' ' + str(max_iter) + " " + str(max_evaluations))
         self.remove_keys(['run', 'velocity'])
-        self.modify(variable___dumptime___equal=n_print, thermo=n_print)
+        self.modify(variable___dumptime='equal '+str(n_print), thermo=n_print)
 
     def calc_static(self):
         self.set(run='0')
@@ -269,6 +269,8 @@ class LammpsControl(GenericParameters):
                                                                      str(temperature),
                                                                      str(temperature_damping_timescale))
         else:  # NVE
+            if langevin:
+                warnings.warn("Temperature not set; Langevin ignored.")
             fix_ensemble_str = 'all nve'
             initial_temperature = 0
 
@@ -277,7 +279,7 @@ class LammpsControl(GenericParameters):
 
         self.remove_keys(["minimize"])
         self.modify(fix___ensemble=fix_ensemble_str,
-                    variable=' dumptime equal {} '.format(n_print),
+                    variable___dumptime=' equal {} '.format(n_print),
                     thermo=int(n_print),
                     run=int(n_ionic_steps),
                     append_if_not_present=True)

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -140,14 +140,14 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self._interactive_lib_command(self._interactive_run_command)
 
     def _interactive_lammps_input(self):
-        del self.input.control['dump']
-        del self.input.control['dump_modify']
+        del self.input.control['dump___1']
+        del self.input.control['dump_modify___1']
         for key, value in zip(self.input.control.dataset['Parameter'], self.input.control.dataset['Value']):
             if key in ['read_data', 'units', 'dimension', 'boundary', 'atom_style', 'atom_modify', 'include', 'run',
                        'minimize']:
                 continue
             else:
-                self._interactive_lib_command(key + ' ' + str(value))
+                self._interactive_lib_command(' '.join(key.split(self.input.control.multi_word_separator)) + ' ' + str(value))
 
     def _interactive_set_potential(self):
         potential_lst = []

--- a/pyiron/testing/randomatomistic.py
+++ b/pyiron/testing/randomatomistic.py
@@ -271,9 +271,9 @@ alat  3.2     # lattice constant (would be in a more realistic example in the st
 alpha 0.1     # noise amplitude
 a_0   3       # equilibrium lattice constant
 a_1   0
-a_2   1.      # 2nd order in energy (corresponds to bulk modulus)
-a_3   0.      # 3rd order
-a_4   0.      # 4th order
+a_2   1.0     # 2nd order in energy (corresponds to bulk modulus)
+a_3   0.0     # 3rd order
+a_4   0.0     # 4th order
 count 10      # number of calls (dummy)
 write_restart True
 read_restart False

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -17,6 +17,8 @@ class TestGenericParameters(unittest.TestCase):
                 par_2 all
                 count 0
                 write_restart True
+                dict {"a": 1, "b": 2}
+                list [1, "s"]
                 read_restart False'''
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
         cls.generic_parameters_str.load_string(my_str)
@@ -25,6 +27,8 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(self.generic_parameters_str.get("par___1"), 1)
         self.assertEqual(self.generic_parameters_str.get("par_2"), 'all')
         self.assertEqual(self.generic_parameters_str.get("count"), 0)
+        self.assertEqual(self.generic_parameters_str.get("dict"), {"a": 1, "b": 2})
+        self.assertEqual(self.generic_parameters_str.get("list"), [1, "s"])
         self.assertTrue(self.generic_parameters_str.get("write_restart"))
         self.assertFalse(self.generic_parameters_str.get("read_restart"))
 
@@ -47,7 +51,9 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(lines[1], 'par_2 all\n')
         self.assertEqual(lines[2], 'count 0\n')
         self.assertEqual(lines[3], 'write_restart True\n')
-        self.assertEqual(lines[4], 'read_restart FALSE\n')
+        # self.assertEqual(lines[4], 'dict {"a": 1, "b": 2}')
+        # self.assertEqual(lines[5], 'list [1, "s"]')
+        self.assertEqual(lines[6], 'read_restart FALSE\n')
         os.remove(file_name)
 
     def test_hdf(self):
@@ -63,6 +69,8 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(gp_reload.get("count"), 0)
         self.assertTrue(gp_reload.get("write_restart"))
         self.assertFalse(gp_reload.get("read_restart"))
+        self.assertEqual(gp_reload.get("dict"), {"a": 1, "b": 2})
+        self.assertEqual(gp_reload.get("list"), [1, "s"])
         os.remove(file_name)
 
     def test_remove_keys(self):

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -50,10 +50,10 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(lines[0], 'par 1 1\n')
         self.assertEqual(lines[1], 'par_2 all\n')
         self.assertEqual(lines[2], 'count 0\n')
-        self.assertEqual(lines[3], 'write_restart TRUE\n')
-        # self.assertEqual(lines[4], 'dict {"a": 1, "b": 2}')
-        # self.assertEqual(lines[5], 'list [1, "s"]')
-        self.assertEqual(lines[6], 'read_restart FALSE\n')
+        self.assertEqual(lines[3], 'write_restart True\n')
+        self.assertEqual(lines[4], "dict {'a': 1, 'b': 2}\n")
+        self.assertEqual(lines[5], "list [1, 's']\n")
+        self.assertEqual(lines[6], 'read_restart False\n')
         os.remove(file_name)
 
     def test_hdf(self):

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -40,13 +40,15 @@ class TestGenericParameters(unittest.TestCase):
 
     def test_write_to_file(self):
         self.generic_parameters_str.write_file(file_name='genpar.txt', cwd=self.file_location)
-        with open(os.path.join(self.file_location, 'genpar.txt',), 'r') as f:
+        file_name = os.path.join(self.file_location, 'genpar.txt')
+        with open(file_name, 'r') as f:
             lines = f.readlines()
         self.assertEqual(lines[0], 'par 1 1\n')
         self.assertEqual(lines[1], 'par_2 all\n')
         self.assertEqual(lines[2], 'count 0\n')
         self.assertEqual(lines[3], 'write_restart True\n')
         self.assertEqual(lines[4], 'read_restart FALSE\n')
+        os.remove(file_name)
 
     def test_hdf(self):
         pr = Project(self.file_location)

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -1,25 +1,29 @@
 from copy import deepcopy
 import pandas
+import os
 from pyiron.base.generic.parameters import GenericParameters
+from pyiron.base.generic.hdfio import ProjectHDFio
+from pyiron.base.project.generic import Project
 import unittest
 
 
 class TestGenericParameters(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.generic_parameters_empty = GenericParameters()
-        cls.generic_parameters_str = GenericParameters()
+        cls.generic_parameters_empty = GenericParameters(table_name='empty')
+        cls.generic_parameters_str = GenericParameters(table_name='str')
         my_str = '''\
                 par_1 1
-                par_2 ab
+                par_2 all
                 count 0
                 write_restart True
                 read_restart False'''
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
         cls.generic_parameters_str.load_string(my_str)
 
     def test_load_string(self):
         self.assertEqual(self.generic_parameters_str.get("par_1"), 1)
-        self.assertEqual(self.generic_parameters_str.get("par_2"), 'ab')
+        self.assertEqual(self.generic_parameters_str.get("par_2"), 'all')
         self.assertEqual(self.generic_parameters_str.get("count"), 0)
         self.assertTrue(self.generic_parameters_str.get("write_restart"))
         self.assertFalse(self.generic_parameters_str.get("read_restart"))
@@ -32,6 +36,21 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(self.generic_parameters_str.get("par_1"), 1)
         self.generic_parameters_str.modify(par_1=3)
         self.assertEqual(self.generic_parameters_str.get("par_1"), 3)
+
+    def test_hdf(self):
+        pr = Project(self.file_location)
+        file_name = os.path.join(self.file_location, 'genericpara.h5')
+        hdf = ProjectHDFio(project=pr, file_name=file_name, h5_path="/test", mode="a")
+        hdf.create_group('test')
+        self.generic_parameters_str.to_hdf(hdf=hdf, group_name='input')
+        gp_reload = GenericParameters(table_name='str')
+        gp_reload.from_hdf(hdf=hdf, group_name='input')
+        self.assertEqual(gp_reload.get("par_1"), 1)
+        self.assertEqual(gp_reload.get("par_2"), 'all')
+        self.assertEqual(gp_reload.get("count"), 0)
+        self.assertTrue(gp_reload.get("write_restart"))
+        self.assertFalse(gp_reload.get("read_restart"))
+        os.remove(file_name)
 
     def test_remove_keys(self):
         self.assertFalse(self.generic_parameters_str.get("read_restart"))

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -13,7 +13,7 @@ class TestGenericParameters(unittest.TestCase):
         cls.generic_parameters_empty = GenericParameters(table_name='empty')
         cls.generic_parameters_str = GenericParameters(table_name='str')
         my_str = '''\
-                par_1 1
+                par___1 1
                 par_2 all
                 count 0
                 write_restart True
@@ -22,7 +22,7 @@ class TestGenericParameters(unittest.TestCase):
         cls.generic_parameters_str.load_string(my_str)
 
     def test_load_string(self):
-        self.assertEqual(self.generic_parameters_str.get("par_1"), 1)
+        self.assertEqual(self.generic_parameters_str.get("par___1"), 1)
         self.assertEqual(self.generic_parameters_str.get("par_2"), 'all')
         self.assertEqual(self.generic_parameters_str.get("count"), 0)
         self.assertTrue(self.generic_parameters_str.get("write_restart"))
@@ -33,9 +33,20 @@ class TestGenericParameters(unittest.TestCase):
                          str(pandas.DataFrame(columns=['Parameter', 'Value', 'Comment'])))
 
     def test_modify(self):
-        self.assertEqual(self.generic_parameters_str.get("par_1"), 1)
-        self.generic_parameters_str.modify(par_1=3)
-        self.assertEqual(self.generic_parameters_str.get("par_1"), 3)
+        self.assertEqual(self.generic_parameters_str.get("par___1"), 1)
+        self.generic_parameters_str.modify(par___1=3)
+        self.assertEqual(self.generic_parameters_str.get("par___1"), 3)
+        self.generic_parameters_str.modify(par___1=1)
+
+    def test_write_to_file(self):
+        self.generic_parameters_str.write_file(file_name='genpar.txt', cwd=self.file_location)
+        with open(os.path.join(self.file_location, 'genpar.txt',), 'r') as f:
+            lines = f.readlines()
+        self.assertEqual(lines[0], 'par 1 1\n')
+        self.assertEqual(lines[1], 'par_2 all\n')
+        self.assertEqual(lines[2], 'count 0\n')
+        self.assertEqual(lines[3], 'write_restart True\n')
+        self.assertEqual(lines[4], 'read_restart FALSE\n')
 
     def test_hdf(self):
         pr = Project(self.file_location)
@@ -45,7 +56,7 @@ class TestGenericParameters(unittest.TestCase):
         self.generic_parameters_str.to_hdf(hdf=hdf, group_name='input')
         gp_reload = GenericParameters(table_name='str')
         gp_reload.from_hdf(hdf=hdf, group_name='input')
-        self.assertEqual(gp_reload.get("par_1"), 1)
+        self.assertEqual(gp_reload.get("par___1"), 1)
         self.assertEqual(gp_reload.get("par_2"), 'all')
         self.assertEqual(gp_reload.get("count"), 0)
         self.assertTrue(gp_reload.get("write_restart"))

--- a/tests/base/generic/test_genericParameters.py
+++ b/tests/base/generic/test_genericParameters.py
@@ -50,7 +50,7 @@ class TestGenericParameters(unittest.TestCase):
         self.assertEqual(lines[0], 'par 1 1\n')
         self.assertEqual(lines[1], 'par_2 all\n')
         self.assertEqual(lines[2], 'count 0\n')
-        self.assertEqual(lines[3], 'write_restart True\n')
+        self.assertEqual(lines[3], 'write_restart TRUE\n')
         # self.assertEqual(lines[4], 'dict {"a": 1, "b": 2}')
         # self.assertEqual(lines[5], 'list [1, "s"]')
         self.assertEqual(lines[6], 'read_restart FALSE\n')

--- a/tests/lammps/test_lammps.py
+++ b/tests/lammps/test_lammps.py
@@ -41,9 +41,13 @@ class TestLammps(unittest.TestCase):
         atoms.selective_dynamics[7] = [False, False, False]
         self.job.structure = atoms
         self.job._set_selective_dynamics()
-        self.assertTrue('group' in self.job.input.control._dataset["Parameter"])
-        para_lst = np.array(self.job.input.control._dataset["Parameter"])
-        self.assertEqual(len(para_lst[para_lst == 'group']), 7)
+        self.assertTrue('group___constraintx' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constrainty' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constraintz' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constraintxy' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constraintyz' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constraintxz' in self.job.input.control._dataset["Parameter"])
+        self.assertTrue('group___constraintxyz' in self.job.input.control._dataset["Parameter"])
 
     def test_structure_atomic(self):
         atoms = Atoms('Fe1', positions=np.zeros((1, 3)), cell=np.eye(3))
@@ -127,7 +131,6 @@ class TestLammps(unittest.TestCase):
                  "cells", "pressures", "unwrapped_positions"]
         with self.job_water.project_hdf5.open("output/generic") as h_gen:
             hdf_nodes = h_gen.list_nodes()
-            print(hdf_nodes, [node in hdf_nodes for node in nodes])
             self.assertTrue(all([node in hdf_nodes for node in nodes]))
         self.assertTrue(np.array_equal(self.job_water["output/generic/positions"].shape, (6, 81, 3)))
         self.assertTrue(np.array_equal(self.job_water["output/generic/positions"].shape,

--- a/tests/testing/test_exampleJob.py
+++ b/tests/testing/test_exampleJob.py
@@ -34,7 +34,16 @@ class TestExampleJob(unittest.TestCase):
                      "count " + str(self.count) + " #number of calls (dummy)\n",
                      "write_restart True\n",
                      "read_restart False\n"]
-        self.assertEqual(input_lst, lines)
+        self.assertEqual(input_lst[0], lines[0])
+        self.assertEqual(input_lst[1], lines[1])
+        self.assertEqual(input_lst[2], lines[2])
+        self.assertEqual(input_lst[3], lines[3])
+        self.assertIn(lines[4], [input_lst[4], "a_2 1. #2nd order in energy (corresponds to bulk modulus)\n"])
+        self.assertIn(lines[5], [input_lst[5], "a_3 0. #3rd order\n"])
+        self.assertIn(lines[6], [input_lst[6], "a_4 0. #4th order\n"])
+        self.assertEqual(input_lst[7], lines[7])
+        self.assertEqual(input_lst[8], lines[8])
+        self.assertEqual(input_lst[9], lines[9])
 
     def test_restart_file(self):
         with open(os.path.join(self.file_location, 'random_testing/job_test_run_hdf5/job_test_run/restart.out')) as restart_file:

--- a/tests/testing/test_exampleJob.py
+++ b/tests/testing/test_exampleJob.py
@@ -34,16 +34,7 @@ class TestExampleJob(unittest.TestCase):
                      "count " + str(self.count) + " #number of calls (dummy)\n",
                      "write_restart True\n",
                      "read_restart False\n"]
-        self.assertEqual(input_lst[0], lines[0])
-        self.assertEqual(input_lst[1], lines[1])
-        self.assertEqual(input_lst[2], lines[2])
-        self.assertEqual(input_lst[3], lines[3])
-        self.assertIn(lines[4], [input_lst[4], "a_2 1. #2nd order in energy (corresponds to bulk modulus)\n"])
-        self.assertIn(lines[5], [input_lst[5], "a_3 0. #3rd order\n"])
-        self.assertIn(lines[6], [input_lst[6], "a_4 0. #4th order\n"])
-        self.assertEqual(input_lst[7], lines[7])
-        self.assertEqual(input_lst[8], lines[8])
-        self.assertEqual(input_lst[9], lines[9])
+        self.assertEqual(input_lst, lines)
 
     def test_restart_file(self):
         with open(os.path.join(self.file_location, 'random_testing/job_test_run_hdf5/job_test_run/restart.out')) as restart_file:

--- a/tests/testing/test_exampleJob.py
+++ b/tests/testing/test_exampleJob.py
@@ -28,9 +28,9 @@ class TestExampleJob(unittest.TestCase):
                      "alpha 0.1 #noise amplitude\n",
                      "a_0 3 #equilibrium lattice constant\n",
                      "a_1 0\n",
-                     "a_2 1. #2nd order in energy (corresponds to bulk modulus)\n",
-                     "a_3 0. #3rd order\n",
-                     "a_4 0. #4th order\n",
+                     "a_2 1.0 #2nd order in energy (corresponds to bulk modulus)\n",
+                     "a_3 0.0 #3rd order\n",
+                     "a_4 0.0 #4th order\n",
                      "count " + str(self.count) + " #number of calls (dummy)\n",
                      "write_restart True\n",
                      "read_restart False\n"]

--- a/tests/testing/test_exampleJob_non_modal.py
+++ b/tests/testing/test_exampleJob_non_modal.py
@@ -35,9 +35,9 @@ class TestExampleJob(unittest.TestCase):
                      "alpha 0.1 #noise amplitude\n",
                      "a_0 3 #equilibrium lattice constant\n",
                      "a_1 0\n",
-                     "a_2 1. #2nd order in energy (corresponds to bulk modulus)\n",
-                     "a_3 0. #3rd order\n",
-                     "a_4 0. #4th order\n",
+                     "a_2 1.0 #2nd order in energy (corresponds to bulk modulus)\n",
+                     "a_3 0.0 #3rd order\n",
+                     "a_4 0.0 #4th order\n",
                      "count " + str(self.count) + " #number of calls (dummy)\n",
                      "write_restart True\n",
                      "read_restart False\n"]


### PR DESCRIPTION
This allows input like:

```
job.input['fix___langevin'] = 'blabla'
```

as we as all the other input items which require more than one term.