### PR TITLE
Set relative

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -693,7 +693,7 @@ class GenericOutput(object):
         """
         displacement = np.tensordot(self.positions,
                                     np.linalg.inv(self._job.structure.cell), axes=([2,0]))
-        displacement -= np.append(self._job.structure.scaled_positions,
+        displacement -= np.append(self._job.structure.get_scaled_positions(),
                                   displacement).reshape(len(self.positions)+1,
                                                         len(self._job.structure), 3)[:-1]
         displacement -= np.rint(displacement)

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -118,8 +118,8 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
                 if not np.allclose(self._structure_current.cell, self._structure_previous.cell, rtol=1e-15, atol=1e-15):
                     self._logger.debug('Generic library: cell changed!')
                     self.interactive_cells_setter(self._structure_current.cell)
-                if not np.allclose(self._structure_current.scaled_positions,
-                                   self._structure_previous.scaled_positions, rtol=1e-15, atol=1e-15):
+                if not np.allclose(self._structure_current.get_scaled_positions(),
+                                   self._structure_previous.get_scaled_positions(), rtol=1e-15, atol=1e-15):
                     self._logger.debug('Generic library: positions changed!')
                     self.interactive_positions_setter(self._structure_current.positions)
                 if np.any(self._structure_current.get_initial_magnetic_moments()) and \

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -233,16 +233,16 @@ class Atoms(object):
 
     @scaled_positions.setter
     def scaled_positions(self, positions):
-        self._scaled_positions = positions
         if self.cell is not None:
             self._positions = np.dot(self.cell.T, np.array(positions).T).T
+        self._scaled_positions = positions
 
     @positions.setter
     def positions(self, positions):
-        self._positions = positions
         if self.cell is not None:
             b_mat = np.linalg.inv(self.cell)
             self._scaled_positions = np.dot(b_mat.T, np.array(positions).T).T
+        self._positions = positions
 
     @property
     def species(self):

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2914,6 +2914,16 @@ class Atoms(object):
         else:
             self.positions = np.transpose(rcoords) + center
 
+    @property
+    def scaled_positions(self):
+        warnings.warn('scaled_positions is deprecated. Use get_scaled_positions instead', DeprecationWarning)
+        return self.get_scaled_positions()
+
+    @scaled_positions.setter
+    def scaled_positions(self, positions):
+        warnings.warn('scaled_positions is deprecated. Use set_scaled_positions instead', DeprecationWarning)
+        self.set_scaled_positions(positions)
+
     def set_scaled_positions(self, scaled):
         """
         Set positions relative to unit cell.

--- a/pyiron/atomistics/structure/phonopy.py
+++ b/pyiron/atomistics/structure/phonopy.py
@@ -31,7 +31,7 @@ def analyse_phonopy_equivalent_atoms(atoms, symprec=1e-5, angle_tolerance=-1.0):
 
     """
     s.publication_add(publication())
-    positions = atoms.scaled_positions
+    positions = atoms.get_scaled_positions()
     cell = atoms.cell
     types = atoms.get_chemical_symbols()
     types = list(types)

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -69,7 +69,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
             try:
                 self.run_if_interactive_non_modal()
                 self.run_if_interactive_non_modal()
-                for atom in self.current_structure.scaled_positions:
+                for atom in self.current_structure.get_scaled_positions():
                     text = ' '.join(map('{:19.16f}'.format, atom))
                     self._interactive_library.stdin.write(text + '\n')
             except BrokenPipeError:
@@ -186,7 +186,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
             for species in atom_numbers.keys():
                 indices = self.current_structure.select_index(species)
                 for i in indices:
-                    text = ' '.join(map('{:19.16f}'.format, self.current_structure.scaled_positions[i]))
+                    text = ' '.join(map('{:19.16f}'.format, self.current_structure.get_scaled_positions()[i]))
                     self._logger.debug('Vasp library: ' + text)
                     self._interactive_library.stdin.write(text + '\n')
             self._interactive_library.stdin.flush()

--- a/pyiron/vasp/structure.py
+++ b/pyiron/vasp/structure.py
@@ -104,7 +104,7 @@ def write_poscar(structure, filename="POSCAR", write_species=True, cartesian=Tru
                 if cartesian:
                     sorted_coords.append(structure.positions[i])
                 else:
-                    sorted_coords.append(structure.scaled_positions[i])
+                    sorted_coords.append(structure.get_scaled_positions()[i])
                 if selec_dyn:
                     selec_dyn_lst.append(structure.selective_dynamics[i])
         if cartesian:

--- a/pyiron/vasp/vasprun.py
+++ b/pyiron/vasp/vasprun.py
@@ -625,7 +625,7 @@ class Vasprun(object):
             if len(positions[positions > 1.01]) > 0:
                 basis.positions = positions
             else:
-                basis.scaled_positions = positions
+                basis.set_scaled_positions(positions)
             return basis
         except (KeyError, AttributeError, ValueError):
             return

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -358,6 +358,8 @@ class TestAtoms(unittest.TestCase):
         self.assertAlmostEqual(basis.positions[-1,0], basis_relative.positions[-1,0])
         basis.cell = 3*np.ones(3)
         self.assertAlmostEqual(basis.get_volume(), 27)
+        basis.cell = np.append(np.ones(3), 90-np.random.random(3)).flatten()
+        self.assertLess(basis.get_volume(), 1)
 
     def test_repeat(self):
         basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -188,7 +188,7 @@ class TestAtoms(unittest.TestCase):
             self.assertEqual(basis.get_majority_species()['symbol'], "Al")
             self.assertEqual(basis.get_spacegroup()['Number'], 225)
 
-    def create_Fe_bcc(self):
+    def test_create_Fe_bcc(self):
         self.pse = PeriodicTable()
         self.pse.add_element("Fe", "Fe_up", spin="up", pseudo_name='GGA')
         self.pse.add_element("Fe", "Fe_down", spin="down", pseudo_name='GGA')
@@ -248,6 +248,10 @@ class TestAtoms(unittest.TestCase):
         basis.set_scaled_positions(np.array([[0.5, 0.5, 0.5]]))
         self.assertTrue(np.array_equal(basis.get_scaled_positions(), [[0.5, 0.5, 0.5]]))
         self.assertTrue(np.array_equal(basis.positions, np.dot([[0.5, 0.5, 0.5]], basis.cell)))
+        with warnings.catch_warnings(record=True) as w:
+            basis.scaled_positions = np.array([[0.5, 0.5, 0.5]])
+            self.assertTrue(np.array_equal(basis.scaled_positions, [[0.5, 0.5, 0.5]]))
+            self.assertEqual(len(w), 2)
 
     def test_cell(self):
         CO = Atoms("CO",
@@ -563,7 +567,7 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(Al.get_symmetry()['translations']), 96)
         self.assertEqual(len(Al.get_symmetry()['translations']), len(Al.get_symmetry()['rotations']))
 
-    def _get_voronoi_vertices(self):
+    def test_get_voronoi_vertices(self):
         cell = 2.2 * np.identity(3)
         Al = Atoms('AlAl', scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell)
         pos, box = Al._get_voronoi_vertices()

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -576,16 +576,6 @@ class TestAtoms(unittest.TestCase):
         pos, box = Al._get_voronoi_vertices()
         self.assertEqual(len(pos), 14)
 
-    def get_equivalent_voronoi_vertices(self):
-        cell = 2.2 * np.identity(3)
-        Al = Atoms('AlAl', positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell).repeat(2)
-        pos, box = Al._get_voronoi_vertices()
-        self.assertEqual(len(Al), 69)
-        self.assertEqual(len(len(Al.get_species_symbols())), 2)
-        Al = Atoms('AlAl', scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell).repeat(2)
-        pos = Al.get_equivalent_voronoi_vertices()
-        self.assertEqual(len(pos), 1)
-
     def test_get_parent_symbols(self):
         self.assertTrue(np.array_equal(self.CO2.get_parent_symbols(), ["C", "O", "O"]))
         self.assertTrue(np.array_equal(self.CO2.get_parent_symbols(), self.CO2.get_chemical_symbols()))

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -251,7 +251,6 @@ class TestAtoms(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             basis.scaled_positions = np.array([[0.5, 0.5, 0.5]])
             self.assertTrue(np.array_equal(basis.scaled_positions, [[0.5, 0.5, 0.5]]))
-            self.assertEqual(len(w), 2)
 
     def test_cell(self):
         CO = Atoms("CO",

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -40,7 +40,6 @@ class TestAtoms(unittest.TestCase):
         self.assertIsInstance(basis.units, dict)
         self.assertIsInstance(basis.pbc, (bool, list, np.ndarray))
         self.assertIsInstance(basis.indices, np.ndarray)
-        self.assertIsNone(basis._internal_positions)
         self.assertIsNone(basis.positions)
         self.assertIsNone(basis.scaled_positions)
         self.assertIsInstance(basis.species, list)
@@ -67,7 +66,6 @@ class TestAtoms(unittest.TestCase):
         self.assertIsInstance(basis.indices, np.ndarray)
         self.assertIsInstance(basis.species, list)
         self.assertIsInstance(basis.cell, np.ndarray)
-        self.assertIsInstance(basis._internal_positions, np.ndarray)
         self.assertIsInstance(basis.positions, np.ndarray)
         self.assertIsInstance(basis.scaled_positions, np.ndarray)
         self.assertIsInstance(basis.elements, np.ndarray)
@@ -336,6 +334,29 @@ class TestAtoms(unittest.TestCase):
         # fcc.set_relative()
         self.assertTrue(np.linalg.norm(fcc.scaled_positions - positions) < 1e-10)
 
+    def test_set_relative(self):
+        lattice = CrystalStructure(element='Al', bravais_basis='fcc', lattice_constants=4)
+        basis_relative = lattice.copy()
+        basis_relative.set_relative()
+        basis_relative.cell[0,0] = 6
+        basis_absolute = lattice.copy()
+        basis_absolute.set_absolute()
+        basis_absolute.cell[0,0] = 6
+        self.assertAlmostEqual(basis_relative.positions[-1,0]*1.5, basis_absolute.positions[-1,0])
+        basis = lattice.copy()
+        self.assertAlmostEqual(basis.scaled_positions[-1,0], basis_relative.scaled_positions[-1,0])
+        basis.cell[0,0] = 6
+        self.assertAlmostEqual(basis.positions[-1,0], basis_absolute.positions[-1,0])
+        basis = lattice.copy()
+        basis_relative = lattice.copy()
+        basis_relative.set_relative()
+        basis.positions[-1,0] = 0.5
+        basis_relative.positions[-1,0] = 0.5
+        self.assertAlmostEqual(basis.positions[-1,0], basis_relative.positions[-1,0])
+        basis.scaled_positions[-1,0] = 0.5
+        basis_relative.scaled_positions[-1,0] = 0.5
+        self.assertAlmostEqual(basis.positions[-1,0], basis_relative.positions[-1,0])
+
     def test_repeat(self):
         basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)
         basis_O = CrystalStructure("O", bravais_basis="fcc", lattice_constant=4.2)
@@ -437,7 +458,7 @@ class TestAtoms(unittest.TestCase):
         NaCl.set_repeat([3, 3, 3])
         NaCl.positions += [2.2, 2.2, 2.2]
         NaCl.center_coordinates_in_unit_cell(origin=-0.5)
-        self.assertTrue(-0.5 < np.min(NaCl.scaled_positions))
+        self.assertTrue(-0.5 <= np.min(NaCl.scaled_positions))
         self.assertTrue(np.max(NaCl.scaled_positions < 0.5))
         NaCl.center_coordinates_in_unit_cell(origin=0.)
         self.assertTrue(0 <= np.min(NaCl.positions))

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -356,6 +356,8 @@ class TestAtoms(unittest.TestCase):
         basis.positions[-1,0] = 0.5
         basis_relative.positions[-1,0] = 0.5
         self.assertAlmostEqual(basis.positions[-1,0], basis_relative.positions[-1,0])
+        basis.cell = 3*np.ones(3)
+        self.assertAlmostEqual(basis.get_volume(), 27)
 
     def test_repeat(self):
         basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -248,7 +248,7 @@ class TestAtoms(unittest.TestCase):
         basis.set_scaled_positions(np.array([[0.5, 0.5, 0.5]]))
         self.assertTrue(np.array_equal(basis.get_scaled_positions(), [[0.5, 0.5, 0.5]]))
         self.assertTrue(np.array_equal(basis.positions, np.dot([[0.5, 0.5, 0.5]], basis.cell)))
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             basis.scaled_positions = np.array([[0.5, 0.5, 0.5]])
             self.assertTrue(np.array_equal(basis.scaled_positions, [[0.5, 0.5, 0.5]]))
 

--- a/tests/vasp/test_vasprun.py
+++ b/tests/vasp/test_vasprun.py
@@ -149,13 +149,13 @@ class TestVasprun(unittest.TestCase):
         for vp in self.vp_list:
             basis = vp.get_initial_structure()
             self.assertIsInstance(basis, Atoms)
-            self.assertTrue(np.max(basis.scaled_positions) < 1.01)
+            self.assertTrue(np.max(basis.get_scaled_positions()) < 1.01)
 
     def test_get_final_structure(self):
         for vp in self.vp_list:
             basis = vp.get_final_structure()
             self.assertIsInstance(basis, Atoms)
-            self.assertTrue(np.max(basis.scaled_positions) < 1.01)
+            self.assertTrue(np.max(basis.get_scaled_positions()) < 1.01)
             self.assertFalse(np.max(basis.positions) < 1.01)
 
     def test_get_electronic_structure(self):


### PR DESCRIPTION
`scaled_positions` had to be abolished for the following reasons:

1. It is not that commonly used
2. It is not possible to keep `positions` and `scaled_positions` synchronised, since when we try to change an element, e.g. via `positions[0,0] = 0.5`, the setter is not called and therefore we have no control over `scaled_positions`.
3. We would like to keep the functionality of `positions` as a numpy array.

Therefore, please use `set_scaled_positions` and `get_scaled_positions` in the future.