### PR TITLE
Eddrmm handling

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -474,18 +474,18 @@ class VaspBase(GenericDFTJob):
                 lines = f.readlines()
             # If the wrong convergence algorithm is chosen, we get the following error.
             # https://cms.mpi.univie.ac.at/vasp-forum/viewtopic.php?f=4&t=17071
-            if not self.get_eddrmm() == "ignore":
+            if not self.get_eddrmm_handling() == "ignore":
                 for l in lines:
                     if "WARNING in EDDRMM: call to ZHEGV failed, returncode =" in l:
-                        if self.get_eddrmm() == "not_converged":
+                        if self.get_eddrmm_handling() == "not_converged":
                             self.status.not_converged = True
                             break
-                        elif self.get_eddrmm() == "restart":
+                        elif self.get_eddrmm_handling() == "restart":
                             self.status.not_converged = True
                             if not self.input.incar["ALGO"].lower() == "normal":
                                 ham_new = self.copy_hamiltonian(self.name + "_normal")
                                 ham_new.input.incar["ALGO"] = "Normal"
-                                ham_new.set_eddrmm()
+                                ham_new.set_eddrmm_handling()
                                 ham_new.run()
                             break
 
@@ -497,7 +497,7 @@ class VaspBase(GenericDFTJob):
             job_name (str): Job name
 
         Returns:
-            vasp.vasp.Vasp instance: New job
+            pyiron.vasp.vasp.Vasp: New job
         """
         ham_new = self.restart(snapshot=0, job_name=job_name)
         ham_new.structure = self.structure
@@ -748,7 +748,7 @@ class VaspBase(GenericDFTJob):
         else:
             s.logger.debug("No magnetic moments")
 
-    def set_eddrmm(self, status="not_converged"):
+    def set_eddrmm_handling(self, status="not_converged"):
         """
         Sets the way, how EDDRMM warning is handled.
 
@@ -760,7 +760,7 @@ class VaspBase(GenericDFTJob):
         else:
             raise ValueError
 
-    def get_eddrmm(self):
+    def get_eddrmm_handling(self):
         """
         Returns:
             str: status of EDDRMM

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -474,10 +474,34 @@ class VaspBase(GenericDFTJob):
                 lines = f.readlines()
             # If the wrong convergence algorithm is chosen, we get the following error.
             # https://cms.mpi.univie.ac.at/vasp-forum/viewtopic.php?f=4&t=17071
-            for l in lines:
-                if "WARNING in EDDRMM: call to ZHEGV failed, returncode =" in l:
-                    self.status.not_converged = True
-                    break
+            if not self.get_eddrmm() == "ignore":
+                for l in lines:
+                    if "WARNING in EDDRMM: call to ZHEGV failed, returncode =" in l:
+                        if self.get_eddrmm() == "not_converged":
+                            self.status.not_converged = True
+                            break
+                        elif self.get_eddrmm() == "restart":
+                            self.status.not_converged = True
+                            if not self.input.incar["ALGO"].lower() == "normal":
+                                ham_new = self.copy_hamiltonian(self.name + "_normal")
+                                ham_new.input.incar["ALGO"] = "Normal"
+                                ham_new.set_eddrmm()
+                                ham_new.run()
+                            break
+
+    def copy_hamiltonian(self, job_name):
+        """
+        Copies a job to new one with a different name.
+
+        Args:
+            job_name (str): Job name
+
+        Returns:
+            vasp.vasp.Vasp instance: New job
+        """
+        ham_new = self.restart(snapshot=0, job_name=job_name)
+        ham_new.structure = self.structure
+        return ham_new
 
     @staticmethod
     def _decompress_files_in_directory(directory):
@@ -723,6 +747,29 @@ class VaspBase(GenericDFTJob):
                 )
         else:
             s.logger.debug("No magnetic moments")
+
+    def set_eddrmm(self, status="not_converged"):
+        """
+        Sets the way, how EDDRMM warning is handled.
+
+        Args:
+            status (str): new status of EDDRMM handling (can be 'not_converged', 'ignore', or 'restart')
+
+        Returns:
+        """
+        if status == "not_converged" or status == "ignore" or status == "restart":
+            self.input._eddrmm = status
+        else:
+            raise ValueError
+
+    def get_eddrmm(self):
+        """
+        Returns the status of EDDRMM handling.
+
+        Returns:
+            (str) status of EDDRMM
+        """
+        return self.input._eddrmm
 
     def set_coulomb_interactions(self, interaction_type=2, ldau_print=True):
         """
@@ -1537,6 +1584,8 @@ class Input:
         self.kpoints = Kpoints(table_name="kpoints")
         self.potcar = Potcar(table_name="potcar")
 
+        self._eddrmm = "not_converged"
+
     def write(self, structure, modified_elements, directory=None):
         """
         Writes all the input files to a specified directory
@@ -1574,6 +1623,9 @@ class Input:
             self.kpoints.to_hdf(hdf5_input)
             self.potcar.to_hdf(hdf5_input)
 
+            vasp_dict = {"eddrmm_handling": self._eddrmm}
+            hdf5_input["vasp_dict"] = vasp_dict
+
     def from_hdf(self, hdf):
         """
         Reads the attributes and reconstructs the object from a hdf file
@@ -1585,6 +1637,9 @@ class Input:
             self.incar.from_hdf(hdf5_input)
             self.kpoints.from_hdf(hdf5_input)
             self.potcar.from_hdf(hdf5_input)
+            if "vasp_dict" in hdf5_input.list_nodes():
+                vasp_dict = hdf5_input["vasp_dict"]
+                self._eddrmm = vasp_dict["eddrmm_handling"]
 
 
 class Output:

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -754,8 +754,6 @@ class VaspBase(GenericDFTJob):
 
         Args:
             status (str): new status of EDDRMM handling (can be 'not_converged', 'ignore', or 'restart')
-
-        Returns:
         """
         if status == "not_converged" or status == "ignore" or status == "restart":
             self.input._eddrmm = status
@@ -764,10 +762,8 @@ class VaspBase(GenericDFTJob):
 
     def get_eddrmm(self):
         """
-        Returns the status of EDDRMM handling.
-
         Returns:
-            (str) status of EDDRMM
+            str: status of EDDRMM
         """
         return self.input._eddrmm
 

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -52,6 +52,16 @@ class TestVasp(unittest.TestCase):
         self.assertIsInstance(self.job._output_parser, Output)
         self.assertIsInstance(self.job._potential, VaspPotentialSetter)
         self.assertTrue(self.job._compress_by_default)
+        self.assertEqual(self.job.get_eddrmm(), "not_converged")
+
+    def test_eddrmm(self):
+        self.job.set_eddrmm("ignore")
+        self.assertEqual(self.job.get_eddrmm(), "ignore")
+        self.job.set_eddrmm("restart")
+        self.assertEqual(self.job.get_eddrmm(), "restart")
+        self.job.set_eddrmm()
+        self.assertEqual(self.job.get_eddrmm(), "not_converged")
+        self.assertRaises(ValueError, self.job.set_eddrmm, status="blah")
 
     def test_potential(self):
         self.assertEqual(self.job.potential, self.job._potential)

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -52,16 +52,16 @@ class TestVasp(unittest.TestCase):
         self.assertIsInstance(self.job._output_parser, Output)
         self.assertIsInstance(self.job._potential, VaspPotentialSetter)
         self.assertTrue(self.job._compress_by_default)
-        self.assertEqual(self.job.get_eddrmm(), "not_converged")
+        self.assertEqual(self.job.get_eddrmm_handling(), "not_converged")
 
     def test_eddrmm(self):
-        self.job.set_eddrmm("ignore")
-        self.assertEqual(self.job.get_eddrmm(), "ignore")
-        self.job.set_eddrmm("restart")
-        self.assertEqual(self.job.get_eddrmm(), "restart")
-        self.job.set_eddrmm()
-        self.assertEqual(self.job.get_eddrmm(), "not_converged")
-        self.assertRaises(ValueError, self.job.set_eddrmm, status="blah")
+        self.job.set_eddrmm_handling("ignore")
+        self.assertEqual(self.job.get_eddrmm_handling(), "ignore")
+        self.job.set_eddrmm_handling("restart")
+        self.assertEqual(self.job.get_eddrmm_handling(), "restart")
+        self.job.set_eddrmm_handling()
+        self.assertEqual(self.job.get_eddrmm_handling(), "not_converged")
+        self.assertRaises(ValueError, self.job.set_eddrmm_handling, status="blah")
 
     def test_potential(self):
         self.assertEqual(self.job.potential, self.job._potential)


### PR DESCRIPTION
Added ways, how to deal with EDDRMM error in VASP. Three ways are possible:

- ignore: Just ignore error.
- not_converged: set status to 'not_converged' (default).
- restart: set status to 'not_converged' and restarts the job with ALGO = 'Normal' and eddrmm = 'not_converged' from initial structure.