### PR TITLE
Stress

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -84,6 +84,7 @@ class LammpsControl(GenericParameters):
                 + "dimension           3\n"
                 + "boundary            p p p\n"
                 + "atom_style          atomic\n"
+                + "atom_modify         map yes\n"
                 + "read_data           structure.inp\n"
                 + "include             potential.inp\n"
                 + "fix___ensemble      all nve\n"

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -563,12 +563,12 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             self._interactive_lib_command("compute st all stress/atom NULL")
             self._interactive_lib_command("run 0")
             self.interactive_cache["stress"] = []
-        ID = self._interactive_library.extract_atom("id", 0)
-        ID = np.array([ID[i] for i in range(len(self.structure))])-1
-        ID = np.arange(len(ID))[np.argsort(ID)]
+        id_lst = self._interactive_library.extract_atom("id", 0)
+        id_lst = np.array([id_lst[i] for i in range(len(self.structure))])-1
+        id_lst = np.arange(len(id_lst))[np.argsort(id_lst)]
         ind = np.array([0, 3, 4, 3, 1, 5, 4, 5, 2])
         ss = self._interactive_library.extract_compute("st", 1, 2)
-        ss = np.array([ss[i][j] for i in range(len(self.structure)) for j in range(6)]).reshape(-1, 6)[ID]
+        ss = np.array([ss[i][j] for i in range(len(self.structure)) for j in range(6)]).reshape(-1, 6)[id_lst]
         ss = ss[:, ind].reshape(len(self.structure), 3, 3)/1.602e6
         if np.matrix.trace(self._interactive_prism.R) != 3:
             ss = np.einsum('ij,njk->nik', self._interactive_prism.R, ss)

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pickle
 import subprocess
 import warnings
+from scipy import constants
 
 from pyiron.lammps.base import LammpsBase
 from pyiron.lammps.structure import UnfoldingPrism
@@ -569,7 +570,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         ind = np.array([0, 3, 4, 3, 1, 5, 4, 5, 2])
         ss = self._interactive_library.extract_compute("st", 1, 2)
         ss = np.array([ss[i][j] for i in range(len(self.structure)) for j in range(6)]).reshape(-1, 6)[id_lst]
-        ss = ss[:, ind].reshape(len(self.structure), 3, 3)/1.602e6
+        ss = ss[:, ind].reshape(len(self.structure), 3, 3)/constants.eV*constants.bar*constants.angstrom**3
         if np.matrix.trace(self._interactive_prism.R) != 3:
             ss = np.einsum('ij,njk->nik', self._interactive_prism.R, ss)
             ss = np.einsum('nij,kj->nik', ss, self._interactive_prism.R)


### PR DESCRIPTION
This was related to the fact that `extract_compute` (as well as `extract_atoms`) was **not** ordered according to the structure definition, i.e. it has to be reordered using `id` with `extract_atoms`.