### PR TITLE
small change to make sure that number of max steps in calc_minimize i…

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -120,9 +120,9 @@ class LammpsControl(GenericParameters):
             + " "
             + str(f_tol)
             + " "
-            + str(max_iter)
+            + str(int(max_iter))
             + " "
-            + str(max_evaluations)
+            + str(int(max_evaluations))
         )
         self.remove_keys(["run", "velocity"])
         self.modify(variable___dumptime="equal " + str(n_print), thermo=n_print)


### PR DESCRIPTION
…s int. In particular, I had a problem with `calc_minimize(max_iter=1e7)`, which was translated to 10000000.0 (of which .0 made the problem)