### PR TITLE
Sxextopt considers magnetism

### DIFF
--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -72,10 +72,10 @@ class SxExtOpt(InteractiveInterface):
             selective_dynamics="selective_dynamics" in structure._tag_list.keys(),
         )
         self._cell = structure.cell
-        #self._elements = structure.get_parent_symbols()
         magmom = np.char.mod('%s', structure.get_initial_magnetic_moments())
-        self._elements = np.char.add(structure.get_parent_symbols(),
-                                     np.char.replace(magmom, '-', 'm'))
+        self._elements = np.char.add(structure.get_parent_symbols(), magmom)
+        self._elements = np.char.replace(self._elements, '-', 'm')
+        self._elements = np.char.replace(self._elements, '.', 'p')
         self._positions = structure.positions
         self._converged = False
 

--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -73,7 +73,7 @@ class SxExtOpt(InteractiveInterface):
         )
         self._cell = structure.cell
         #self._elements = structure.get_parent_symbols()
-        magmom = np.char.mod('%d', structure.get_initial_magnetic_moments())
+        magmom = np.char.mod('%s', structure.get_initial_magnetic_moments())
         self._elements = np.char.add(structure.get_parent_symbols(),
                                      np.char.replace(magmom, '-', 'm'))
         self._positions = structure.positions

--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -72,7 +72,10 @@ class SxExtOpt(InteractiveInterface):
             selective_dynamics="selective_dynamics" in structure._tag_list.keys(),
         )
         self._cell = structure.cell
-        self._elements = structure.get_parent_symbols()
+        #self._elements = structure.get_parent_symbols()
+        magmom = np.char.mod('%d', structure.get_initial_magnetic_moments())
+        self._elements = np.char.add(structure.get_parent_symbols(),
+                                     np.char.replace(magmom, '-', 'm'))
         self._positions = structure.positions
         self._converged = False
 


### PR DESCRIPTION
For the symmetry calculation of SxExtOpt, initial magnetic moments are also taken into account with this update. This update will not affect the behaviour for the old version (i.e. if an old version of SxExtOpt is used, the symmetry is calculated without taking magnetic moments into account).