### PR TITLE
Sxextopt str

### DIFF
--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -72,7 +72,9 @@ class SxExtOpt(InteractiveInterface):
             selective_dynamics="selective_dynamics" in structure._tag_list.keys(),
         )
         self._cell = structure.cell
-        magmom = np.char.mod('%s', structure.get_initial_magnetic_moments())
+        magmom = structure.get_initial_magnetic_moments()
+        magmom[magmom!=None] = np.round(magmom[magmom!=None], decimals=1)
+        magmom = np.char.mod('%s', magmom)
         self._elements = np.char.add(structure.get_parent_symbols(), magmom)
         self._elements = np.char.replace(self._elements, '-', 'm')
         self._elements = np.char.replace(self._elements, '.', 'p')

--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -395,12 +395,12 @@ class Input(GenericParameters):
         Loads the default file content
         """
         file_content = (
-            "ionic_steps = 1000\n"
+            "ionic_steps = 1000 // maximum number of ionic steps\n"
             "ionic_energy = 1.0e-3\n"
             "ionic_forces = 1.0e-2\n"
-            "maxDist = 5\n"
-            "max_step_length = 1.0e-1\n"
-            "soft_mode_damping = 1.0\n"
+            "maxDist = 5 // maximum possible distance for considering neighbors\n"
+            "max_step_length = 1.0e-1 // maximum displacement at each step\n"
+            "soft_mode_damping = 1.0 // Tikhonov damper\n"
         )
         self.load_string(file_content)
 


### PR DESCRIPTION
Added explanations to the input parameters.

Magnetic moments are rounded for the ID's because otherwise SxExtOpt things there are a lot of different atom types.