### PR TITLE
bugfix in set_value: (Felix's commit)

### DIFF
--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -471,9 +471,6 @@ class GenericParameters(PyironObject):
             new_array.append(val)
             new_comments.append("")
             new_params.append("")
-            new_array = np.array(new_array).tolist()
-            new_comments = np.array(new_comments).tolist()
-            new_params = np.array(new_params).tolist()
             new_dict = OrderedDict()
             new_dict["Value"] = new_array
             new_dict["Comment"] = new_comments

--- a/pyiron/base/generic/parameters.py
+++ b/pyiron/base/generic/parameters.py
@@ -471,9 +471,9 @@ class GenericParameters(PyironObject):
             new_array.append(val)
             new_comments.append("")
             new_params.append("")
-            new_array = np.array(new_array)
-            new_comments = np.array(new_comments)
-            new_params = np.array(new_params)
+            new_array = np.array(new_array).tolist()
+            new_comments = np.array(new_comments).tolist()
+            new_params = np.array(new_params).tolist()
             new_dict = OrderedDict()
             new_dict["Value"] = new_array
             new_dict["Comment"] = new_comments


### PR DESCRIPTION
To ensure the `GenericParameters` avoids storing `numpy` arrays in the HDF5 file