### PR TITLE
full_table now allows users to see the entire pandas queue table

### DIFF
--- a/pyiron/base/database/jobtable.py
+++ b/pyiron/base/database/jobtable.py
@@ -174,6 +174,7 @@ def job_table(
         all_columns (bool): Select all columns - this overwrites the columns option.
         sort_by (str): Sort by a specific column
         max_colwidth (int): set the column width
+        full_table (bool): Whether to show the entire pandas table
         element_lst (list): list of elements required in the chemical formular - by default None
         job_name_contains (str): a string which should be contained in every job_name
 
@@ -210,10 +211,13 @@ def job_table(
         recursive=recursive,
         element_lst=element_lst,
     )
-    pandas.set_option("display.max_colwidth", max_colwidth)
     if full_table:
         pandas.set_option('display.max_rows', None)
-        pandas.set_optn('display.max_columns', None)
+        pandas.set_option('display.max_columns', None)
+    else:
+        pandas.reset_option('display.max_rows')
+        pandas.reset_option('display.max_columns')
+    pandas.set_option("display.max_colwidth", max_colwidth)
     df = pandas.DataFrame(job_dict)
     if len(job_dict) == 0:
         return df

--- a/pyiron/base/database/jobtable.py
+++ b/pyiron/base/database/jobtable.py
@@ -154,6 +154,7 @@ def job_table(
     all_columns=False,
     sort_by="id",
     max_colwidth=200,
+    full_table=False,
     element_lst=None,
     job_name_contains='',
 ):
@@ -210,6 +211,9 @@ def job_table(
         element_lst=element_lst,
     )
     pandas.set_option("display.max_colwidth", max_colwidth)
+    if full_table:
+        pandas.set_option('display.max_rows', None)
+        pandas.set_optn('display.max_columns', None)
     df = pandas.DataFrame(job_dict)
     if len(job_dict) == 0:
         return df

--- a/pyiron/base/project/generic.py
+++ b/pyiron/base/project/generic.py
@@ -822,14 +822,9 @@ class Project(ProjectPath):
         Returns:
             pandas.DataFrame: Output from the queuing system - optimized for the Sun grid engine
         """
-        if full_table:
-            pandas.set_option('display.max_rows', None)
-            pandas.set_option('display.max_columns', None)
-        else:
-            pandas.reset_option('display.max_rows')
-            pandas.reset_option('display.max_columns')
         return queue_table(
-            job_ids=self.get_job_ids(recursive=recursive), project_only=project_only
+            job_ids=self.get_job_ids(recursive=recursive), project_only=project_only,
+            full_table=full_table
         )
 
     def queue_table_global(self, full_table=False):

--- a/pyiron/base/project/generic.py
+++ b/pyiron/base/project/generic.py
@@ -806,7 +806,7 @@ class Project(ProjectPath):
         new._filter = ["nodes"]
         return new
 
-    def queue_table(self, project_only=True, recursive=True):
+    def queue_table(self, project_only=True, recursive=True, full_table=False):
         """
         Display the queuing system table as pandas.Dataframe
 
@@ -817,17 +817,23 @@ class Project(ProjectPath):
         Returns:
             pandas.DataFrame: Output from the queuing system - optimized for the Sun grid engine
         """
+        if full_table:
+            pandas.set_option('display.max_rows', None)
+            pandas.set_option('display.max_columns', None)
         return queue_table(
             job_ids=self.get_job_ids(recursive=recursive), project_only=project_only
         )
 
-    def queue_table_global(self):
+    def queue_table_global(self, full_table=False):
         """
         Display the queuing system table as pandas.Dataframe
 
         Returns:
             pandas.DataFrame: Output from the queuing system - optimized for the Sun grid engine
         """
+        if full_table:
+            pandas.set_option('display.max_rows', None)
+            pandas.set_option('display.max_columns', None)
         df = queue_table(job_ids=[], project_only=False)
         if len(df) != 0 and self.db is not None:
             return pandas.DataFrame(

--- a/pyiron/base/project/generic.py
+++ b/pyiron/base/project/generic.py
@@ -532,6 +532,7 @@ class Project(ProjectPath):
         columns=None,
         all_columns=True,
         sort_by="id",
+        full_table=False,
         element_lst=None,
         job_name_contains='',
     ):
@@ -546,6 +547,7 @@ class Project(ProjectPath):
                             'hamversion', 'parentid', 'masterid']
             all_columns (bool): Select all columns - this overwrites the columns option.
             sort_by (str): Sort by a specific column
+            full_table (bool): Whether to show the entire pandas table
             element_lst (list): list of elements required in the chemical formular - by default None
             job_name_contains (str): a string which should be contained in every job_name
 
@@ -562,6 +564,7 @@ class Project(ProjectPath):
                 columns=columns,
                 all_columns=all_columns,
                 sort_by=sort_by,
+                full_table=full_table,
                 element_lst=element_lst,
                 job_name_contains=job_name_contains,
             )
@@ -573,6 +576,7 @@ class Project(ProjectPath):
                 all_columns=all_columns,
                 sort_by=sort_by,
                 max_colwidth=200,
+                full_table=full_table,
                 job_name_contains=job_name_contains)
 
     def get_jobs_status(self, recursive=True, element_lst=None):
@@ -813,6 +817,7 @@ class Project(ProjectPath):
         Args:
             project_only (bool): Query only for jobs within the current project - True by default
             recursive (bool): Include jobs from sub projects
+            full_table (bool): Whether to show the entire pandas table
 
         Returns:
             pandas.DataFrame: Output from the queuing system - optimized for the Sun grid engine
@@ -820,6 +825,9 @@ class Project(ProjectPath):
         if full_table:
             pandas.set_option('display.max_rows', None)
             pandas.set_option('display.max_columns', None)
+        else:
+            pandas.reset_option('display.max_rows')
+            pandas.reset_option('display.max_columns')
         return queue_table(
             job_ids=self.get_job_ids(recursive=recursive), project_only=project_only
         )
@@ -828,13 +836,13 @@ class Project(ProjectPath):
         """
         Display the queuing system table as pandas.Dataframe
 
+        Args:
+            full_table (bool): Whether to show the entire pandas table
+
         Returns:
             pandas.DataFrame: Output from the queuing system - optimized for the Sun grid engine
         """
-        if full_table:
-            pandas.set_option('display.max_rows', None)
-            pandas.set_option('display.max_columns', None)
-        df = queue_table(job_ids=[], project_only=False)
+        df = queue_table(job_ids=[], project_only=False, full_table=full_table)
         if len(df) != 0 and self.db is not None:
             return pandas.DataFrame(
                 [

--- a/pyiron/base/server/queuestatus.py
+++ b/pyiron/base/server/queuestatus.py
@@ -27,7 +27,7 @@ QUEUE_SCRIPT_PREFIX = "pi_"
 s = Settings()
 
 
-def queue_table(job_ids=[], project_only=True):
+def queue_table(job_ids=[], project_only=True, full_table=False):
     """
     Display the queuing system table as pandas.Dataframe
 
@@ -41,6 +41,12 @@ def queue_table(job_ids=[], project_only=True):
     if project_only and not job_ids:
         return []
     if s.queue_adapter is not None:
+        if full_table:
+            pandas.set_option('display.max_rows', None)
+            pandas.set_option('display.max_columns', None)
+        else:
+            pandas.reset_option('display.max_rows')
+            pandas.reset_option('display.max_columns')
         df = s.queue_adapter.get_status_of_my_jobs()
         if not project_only:
             return df[


### PR DESCRIPTION
`pr.job_table(full_table=True)` will show the entire table, regardless of the number of jobs. The same applies to `queue_table()` and `queue_table_global()`. For `job_table`, there could be a conflict with `max_colwidth` (which I don't think is a problem).