### PR TITLE
Lammps triclinic repairs and extension

### DIFF
--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -555,20 +555,14 @@ class LammpsBase(AtomisticGenericJob):
                 hdf_output[k] = np.array(v)
 
     def calc_minimize(
-        self, e_tol=0.0, f_tol=1e-2, max_iter=100000, pressure=None, n_print=100
+            self,
+            e_tol=0.0,
+            f_tol=1e-4,
+            max_iter=100000,
+            pressure=None,
+            n_print=100
     ):
-        """
-
-        Args:
-            e_tol:
-            f_tol:
-            max_iter:
-            pressure:
-            n_print:
-
-        Returns:
-
-        """
+        # Docstring set programmatically -- Ensure that changes to signature or defaults stay consistent!
         super(LammpsBase, self).calc_minimize(
             e_tol=e_tol,
             f_tol=f_tol,
@@ -583,6 +577,7 @@ class LammpsBase(AtomisticGenericJob):
             pressure=pressure,
             n_print=n_print,
         )
+    calc_minimize.__doc__ = LammpsControl.calc_minimize.__doc__
 
     def calc_static(self):
         """

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -559,7 +559,8 @@ class LammpsBase(AtomisticGenericJob):
             f_tol=1e-4,
             max_iter=100000,
             pressure=None,
-            n_print=100
+            n_print=100,
+            style='cg'
     ):
         # Docstring set programmatically -- Ensure that changes to signature or defaults stay consistent!
         super(LammpsBase, self).calc_minimize(
@@ -576,6 +577,7 @@ class LammpsBase(AtomisticGenericJob):
             max_iter=max_iter,
             pressure=pressure,
             n_print=n_print,
+            style=style,
         )
     calc_minimize.__doc__ = LammpsControl.calc_minimize.__doc__
 

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -986,7 +986,15 @@ class LammpsBase(AtomisticGenericJob):
         lmp_structure.el_eam_lst = self.input.potential.get_element_lst()
 
         def structure_to_lammps(structure):
-            """Converts a structure to the Lammps coordinate frame"""
+            """
+            Converts a structure to the Lammps coordinate frame
+
+            Args:
+                structure (pyiron.atomistics.structure.atoms.Atoms): Structure to convert.
+
+            Returns:
+                pyiron.atomistics.structure.atoms.Atoms: Structure with the LAMMPS coordinate frame.
+            """
             prism = UnfoldingPrism(structure.cell)
             lammps_structure = structure.copy()
             lammps_structure.cell = prism.A

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -1127,7 +1127,7 @@ class LammpsBase(AtomisticGenericJob):
 
             if non_diagonal_pressures and not self._prism.is_skewed():
                 skew_structure = self.structure.copy()
-                skew_structure.cell[0, 1] += self._prism.acc
+                skew_structure.cell[0, 1] += 2 * self._prism.acc
                 self.structure = skew_structure
 
 

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -1129,7 +1129,7 @@ class LammpsBase(AtomisticGenericJob):
 
             if non_diagonal_pressures:
                 try:
-                    if self._prism.is_skewed():
+                    if not self._prism.is_skewed():
                         skew_structure = self.structure.copy()
                         skew_structure.cell[0, 1] += 2 * self._prism.acc
                         self.structure = skew_structure

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -703,7 +703,6 @@ class LammpsBase(AtomisticGenericJob):
             contain at least one atom of each species.
 
         Warning:
-            - Assumes the units are metal, otherwise units for the constraints may be off.
             - The fix does not yet support non-orthogonal simulation boxes; using one will give a runtime error.
 
         Args:

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -414,6 +414,9 @@ class LammpsBase(AtomisticGenericJob):
         Returns:
 
         """
+        prism = UnfoldingPrism(self.structure.cell, digits=15)
+        if np.matrix.trace(self.prism.R) != 3:
+            raise RuntimeError("The Lammps output will not be mapped back to pyiron correctly.")
         file_name = self.job_file_name(file_name=file_name, cwd=cwd)
         with h5py.File(file_name, mode="r", libver="latest", swmr=True) as h5md:
             positions = [

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -879,7 +879,7 @@ class LammpsBase(AtomisticGenericJob):
                 )
             ).split()
         ).reshape(len(natoms), -1)
-        cells = np.array([to_amat(cc) for cc in cells])
+        cells = np.array([prism.unfold_cell(to_amat(cc)) for cc in cells])
         output["cells"] = cells
         l_start = np.where([ll.startswith("ITEM: ATOMS") for ll in dump])[0]
         l_end = l_start + natoms + 1

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -295,7 +295,6 @@ class LammpsBase(AtomisticGenericJob):
         """
         if self.structure is None:
             raise ValueError("Input structure not set. Use method set_structure()")
-        self._prism = UnfoldingPrism(self.structure.cell)
         lmp_structure = self._get_lammps_structure(
             structure=self.structure, cutoff_radius=self.cutoff_radius
         )

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -873,7 +873,7 @@ class LammpsBase(AtomisticGenericJob):
             " ".join(
                 (
                     [
-                        " ".join(dump[nn : nn + 3])
+                        " ".join(dump[nn:nn + 3])
                         for nn in np.where(
                             [ll.startswith("ITEM: BOX BOUNDS") for ll in dump]
                         )[0]

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -844,7 +844,7 @@ class LammpsBase(AtomisticGenericJob):
         with open(file_name, "r") as ff:
             dump = ff.readlines()
         prism = UnfoldingPrism(self.structure.cell, digits=15)
-        rotation_lammps2orig = np.linalg.inv(prism.R)
+        rotation_lammps2orig = prism.R.T
         time = np.genfromtxt(
             [
                 dump[nn]

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -415,7 +415,7 @@ class LammpsBase(AtomisticGenericJob):
 
         """
         prism = UnfoldingPrism(self.structure.cell, digits=15)
-        if np.matrix.trace(self.prism.R) != 3:
+        if np.matrix.trace(prism.R) != 3:
             raise RuntimeError("The Lammps output will not be mapped back to pyiron correctly.")
         file_name = self.job_file_name(file_name=file_name, cwd=cwd)
         with h5py.File(file_name, mode="r", libver="latest", swmr=True) as h5md:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -353,7 +353,7 @@ class LammpsControl(GenericParameters):
                 performed. A length-3 list or array may be given to specify x-, y- and z-components individually. In
                 this case, floats and `None` may be mixed to allow relaxation only in particular directions.
             n_ionic_steps (int): Number of ionic steps
-            time_step (float): Step size between two steps. In fs if units==metal
+            time_step (float): Step size in fs between two steps.
             n_print (int):  Print frequency
             temperature_damping_timescale (float): The time associated with the thermostat adjusting the temperature.
                                                    (In fs. After rescaling to appropriate time units, is equivalent to

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -104,15 +104,16 @@ class LammpsControl(GenericParameters):
         self, e_tol=0.0, f_tol=1e-8, max_iter=100000, pressure=None, n_print=100
     ):
         max_evaluations = 10 * max_iter
+        GPA_TO_BAR = 1.0e4
         if pressure is not None:
             if type(pressure) == float or type(pressure) == int:
                 pressure = pressure * np.ones(3)
             str_press = ""
-            for press, str_axis in zip(pressure, [" x ", " y ", " z "]):
+            for press, str_axis in zip(pressure, [" x ", " y ", " z ", " xy ", " xz ", " yz "][:len(pressure)]):
                 if press is not None:
-                    str_press += str_axis + str(press * 1.0e4)
+                    str_press += str_axis + str(press * GPA_TO_BAR)
             if len(str_press) == 0:
-                raise ValueError("Pressure values cannot be three times None")
+                raise ValueError("Pressure values cannot all be None")
             elif len(str_press) > 1:
                 str_press += " couple none"
             self.set(fix___ensemble=r"all box/relax" + str_press)

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -132,7 +132,10 @@ class LammpsControl(GenericParameters):
         # pyiron.lammps.interactive.LammpsInteractive.calc_minimize -- Please ensure that changes to signature or
         # defaults stay consistent!
         max_evaluations = 10 * max_iter
-        GPA_TO_BAR = 1.0e4
+        GPA_TO_BAR = spc.giga * 1.0 / spc.bar
+        if self["units"] != "metal":
+            raise NotImplementedError
+
         if pressure is not None:
             if type(pressure) == float or type(pressure) == int:
                 pressure = pressure * np.ones(3)

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -22,32 +22,92 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-# Conversion factors for transfroming pyiron units to Lammps units
+# Conversion factors for transfroming pyiron units to Lammps units (alphabetical)
+AMU_TO_G = spc.atomic_mass * spc.kilo
+AMU_TO_KG = spc.atomic_mass
+ANG_PER_FS_TO_ANG_PER_PS = spc.pico / spc.femto
+ANG_PER_FS_TO_BOHR_PER_FS = spc.angstrom / spc.physical_constants['Bohr radius'][0]
+ANG_PER_FS_TO_CM_PER_S = (spc.angstrom / spc.femto) / spc.centi
+ANG_PER_FS_TO_M_PER_S = spc.angstrom / spc.femto
+ANG_TO_BOHR = spc.angstrom / spc.physical_constants['Bohr radius'][0]
+ANG_TO_CM = spc.angstrom / spc.centi
+ANG_TO_M = spc.angstrom
+EL_TO_COUL = spc.elementary_charge
+EV_PER_ANG_TO_DYNE = (spc.electron_volt / spc.angstrom) / spc.dyne
+EV_PER_ANG_TO_HA_PER_BOHR = spc.physical_constants["electron volt-hartree relationship"][0] * \
+                            spc.physical_constants['Bohr radius'][0] / spc.angstrom
+EV_PER_ANG_TO_KCAL_PER_MOL_ANG = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
+EV_PER_ANG_TO_N = spc.electron_volt / spc.angstrom
+EV_TO_ERG = spc.electron_volt / spc.erg
+EV_TO_HA = spc.physical_constants["electron volt-hartree relationship"][0]
+EV_TO_J = spc.electron_volt
+EV_TO_KCAL_PER_MOL = spc.eV / (spc.kilo * spc.calorie / spc.N_A)
 FS_TO_PS = spc.femto / spc.pico
-FS_TO_S = spc.femto / 1.0
-GPA_TO_BAR = spc.giga * 1.0 / spc.bar
+FS_TO_S = spc.femto
+GPA_TO_ATM = spc.giga / spc.atm
+GPA_TO_BAR = spc.giga / spc.bar
+GPA_TO_BARYE = spc.giga / (spc.micro * spc.bar)  # "barye" = 1e-6 bar
 GPA_TO_PA = spc.giga
-GPA_TO_BARYE = spc.giga * 1.0 / (1.0e-6 * spc.bar)  # Lammps is in "barye"
-GPA_TO_ATM = spc.giga * 1.0 / spc.atm
+
+# Conversions for most of the Lammps units to Pyiron units
+# Lammps units source doc: https://lammps.sandia.gov/doc/units.html
+# Pyrion units source doc: https://pyiron.github.io/source/faq.html
+# At time of writing, not all these conversion factors are used, but may be helpful later.
 LAMMPS_UNIT_CONVERSIONS = {
     "metal": {
+        "mass": 1.,
+        "distance": 1.,
         "time": FS_TO_PS,
-        "pressure": GPA_TO_BAR
+        "energy": 1.,
+        "velocity": ANG_PER_FS_TO_ANG_PER_PS,
+        "force": 1.,
+        "temperature": 1.,
+        "pressure": GPA_TO_BAR,
+        "charge": 1.
     },
     "si": {
+        "mass": AMU_TO_KG,
+        "distance": ANG_TO_M,
         "time": FS_TO_S,
-        "pressure": GPA_TO_PA
+        "energy": EV_TO_J,
+        "velocity": ANG_PER_FS_TO_M_PER_S,
+        "force": EV_PER_ANG_TO_N,
+        "temperature": 1.,
+        "pressure": GPA_TO_PA,
+        "charge": EL_TO_COUL
     },
     "cgs": {
+        "mass": AMU_TO_G,
+        "distance": ANG_TO_CM,
         "time": FS_TO_S,
-        "pressure": GPA_TO_BARYE
+        "energy": EV_TO_ERG,
+        "velocity": ANG_PER_FS_TO_CM_PER_S,
+        "force": EV_PER_ANG_TO_DYNE,
+        "temperature": 1.,
+        "pressure": GPA_TO_BARYE,
+        "charge": 4.8032044e-10  # In statCoulombs, but these are deprecated and thus not in scipt.constants
     },
     "real": {
-        "time": 1,
-        "pressure": GPA_TO_ATM
+        "mass": 1.,
+        "distance": 1.,
+        "time": 1.,
+        "energy": EV_TO_KCAL_PER_MOL,
+        "velocity": 1.,
+        "force": EV_PER_ANG_TO_KCAL_PER_MOL_ANG,
+        "temperature": 1.,
+        "pressure": GPA_TO_ATM,
+        "charge": 1.
     },
     "electron": {
-        "time": 1, "pressure": GPA_TO_PA
+        "mass": 1.,
+        "distance": ANG_TO_BOHR,
+        "time": 1.,
+        "energy": EV_TO_HA,
+        "velocity": ANG_PER_FS_TO_BOHR_PER_FS,
+        "force": EV_PER_ANG_TO_HA_PER_BOHR,
+        "temperature": 1.,
+        "pressure": GPA_TO_PA,
+        "charge": 1.
     },
 }
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -407,7 +407,8 @@ class LammpsControl(GenericParameters):
             pressure_damping_timescale *= time_units
 
         # Transform temperature
-        temperature *= temperature_units
+        if temperature is not None:
+            temperature *= temperature_units
 
         # Apply initial overheating (default uses the theorem of equipartition of energy between KE and PE)
         if initial_temperature is None and temperature is not None:
@@ -588,6 +589,8 @@ class LammpsControl(GenericParameters):
         energy_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["energy"]
 
         if temperature_mc is None:
+            if temperature is None:
+                raise ValueError("If temperature is not given, temperature_mc must be.")
             temperature_mc = temperature * temperature_units
 
         if seed is None:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -120,11 +120,12 @@ class LammpsControl(GenericParameters):
                 `max_iter` steps, terminate at the converged step. If the minimisation does not converge up to
                 `max_iter` steps, terminate at the `max_iter` step. (Default is 100000.)
             pressure (float/list/tuple/numpy.ndarray): Pressure in GPa at which minimisation is to be carried out. If
-                None, isochoric (constant volume) condition will be used. If a float, isotropic cell shape changes are
-                allowed. If array-like, (up to) the first six elements will be interpreted as the x, y, z, xy, xz, and
-                yz components of the pressure tensor, respectively. If this component-wise mode is used, cell changes
-                corresponding to any one element of the stress tensor can be selectively disabled by setting this
-                element to None. (Default is None, run isochorically.)
+                None, isochoric (constant volume) condition will be used. If a float, cell shape changes are allowed.
+                in each of the three primary axes, but no shearing occurs. If array-like, (up to) the first six
+                elements will be interpreted as the x, y, z, xy, xz, and yz components of the pressure tensor,
+                respectively. If this component-wise mode is used, cell changes corresponding to any one element of the
+                stress tensor can be selectively disabled by setting this element to None. (Default is None, run
+                isochorically.)
             n_print (int): Write (dump or print) to the output file every n steps (Default: 100)
         """
         # This docstring is a source for the calc_minimize method in pyiron.lammps.base.LammpsBase.calc_minimize and

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -331,21 +331,22 @@ class LammpsControl(GenericParameters):
             if not hasattr(pressure, "__len__"):
                 pressure = pressure * np.ones(3)
             else:
-                pressure = np.array(pressure)
+                pressure = np.array(pressure, dtype=float)
 
-            if sum(pressure != None) == 0:
+            not_none_mask = [p is not None for p in pressure]
+            if not np.any(not_none_mask):
                 raise ValueError("Pressure cannot be three times None")
 
-            if len(pressure) != 3:
-                raise ValueError("Pressure must be a float or a 3d vector")
+            if len(pressure) > 6:
+                raise ValueError("Pressure must be a float or a vector with length <= 6")
 
             if temperature is None or temperature == 0.0:
                 raise ValueError("Target temperature for fix nvt/npt/nph cannot be 0")
 
-            pressure[pressure != None] *= pressure_units
+            pressure[not_none_mask] *= pressure_units
 
             pressure_string = ""
-            for coord, value in zip(["x", "y", "z"], pressure):
+            for coord, value in zip(["x", "y", "z", "xy", "xz", "yz"][:len(pressure)], pressure):
                 if value is not None:
                     pressure_string += " {0} {1} {1} {2}".format(
                         coord, str(value), str(pressure_damping_timescale)

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -101,8 +101,35 @@ class LammpsControl(GenericParameters):
         self.load_string(file_content)
 
     def calc_minimize(
-        self, e_tol=0.0, f_tol=1e-8, max_iter=100000, pressure=None, n_print=100
+        self,
+        e_tol=0.0,
+        f_tol=1e-4,
+        max_iter=100000,
+        pressure=None,
+        n_print=100
     ):
+        """
+        Sets parameters required for minimization.
+
+        Args:
+            e_tol (float): If the magnitude of difference between energies of two consecutive steps is lower than or
+                equal to `e_tol`, the minimisation terminates. (Default is 0.0 eV.)
+            f_tol (float): If the magnitude of the global force vector at a step is lower than or equal to `f_tol`, the
+                minimisation terminates. (Default is 1e-4 eV/angstrom.)
+            max_iter (int): Maximum number of minimisation steps to carry out. If the minimisation converges before
+                `max_iter` steps, terminate at the converged step. If the minimisation does not converge up to
+                `max_iter` steps, terminate at the `max_iter` step. (Default is 100000.)
+            pressure (float/list/tuple/numpy.ndarray): Pressure in GPa at which minimisation is to be carried out. If
+                None, isochoric (constant volume) condition will be used. If a float, isotropic cell shape changes are
+                allowed. If array-like, (up to) the first six elements will be interpreted as the x, y, z, xy, xz, and
+                yz components of the pressure tensor, respectively. If this component-wise mode is used, cell changes
+                corresponding to any one element of the stress tensor can be selectively disabled by setting this
+                element to None. (Default is None, run isochorically.)
+            n_print (int): Write (dump or print) to the output file every n steps (Default: 100)
+        """
+        # This docstring is a source for the calc_minimize method in pyiron.lammps.base.LammpsBase.calc_minimize and
+        # pyiron.lammps.interactive.LammpsInteractive.calc_minimize -- Please ensure that changes to signature or
+        # defaults stay consistent!
         max_evaluations = 10 * max_iter
         GPA_TO_BAR = 1.0e4
         if pressure is not None:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -106,7 +106,8 @@ class LammpsControl(GenericParameters):
         f_tol=1e-4,
         max_iter=100000,
         pressure=None,
-        n_print=100
+        n_print=100,
+        style='cg'
     ):
         """
         Sets parameters required for minimization.
@@ -127,11 +128,14 @@ class LammpsControl(GenericParameters):
                 stress tensor can be selectively disabled by setting this element to None. (Default is None, run
                 isochorically.)
             n_print (int): Write (dump or print) to the output file every n steps (Default: 100)
+            style ('cg'/'sd'/other values from Lammps docs): The style of the numeric minimization, either conjugate
+                gradient, steepest descent, or other keys permissible from the Lammps docs on 'min_style'. (Default
+                is 'cg' -- conjugate gradient.)
         """
         # This docstring is a source for the calc_minimize method in pyiron.lammps.base.LammpsBase.calc_minimize and
         # pyiron.lammps.interactive.LammpsInteractive.calc_minimize -- Please ensure that changes to signature or
         # defaults stay consistent!
-        max_evaluations = 10 * max_iter
+        max_evaluations = 100 * max_iter
         GPA_TO_BAR = spc.giga * 1.0 / spc.bar
         if self["units"] != "metal":
             raise NotImplementedError
@@ -150,6 +154,7 @@ class LammpsControl(GenericParameters):
             self.set(fix___ensemble=r"all box/relax" + str_press)
         else:
             self.remove_keys(["fix___nve"])
+        self.set(min_style=style)
         self.set(
             minimize=str(e_tol)
             + " "

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -22,6 +22,36 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
+# Conversion factors for transfroming pyiron units to Lammps units
+FS_TO_PS = spc.femto / spc.pico
+FS_TO_S = spc.femto / 1.0
+GPA_TO_BAR = spc.giga * 1.0 / spc.bar
+GPA_TO_PA = spc.giga
+GPA_TO_BARYE = spc.giga * 1.0 / (1.0e-6 * spc.bar)  # Lammps is in "barye"
+GPA_TO_ATM = spc.giga * 1.0 / spc.atm
+LAMMPS_UNIT_CONVERSIONS = {
+    "metal": {
+        "time": FS_TO_PS,
+        "pressure": GPA_TO_BAR
+    },
+    "si": {
+        "time": FS_TO_S,
+        "pressure": GPA_TO_PA
+    },
+    "cgs": {
+        "time": FS_TO_S,
+        "pressure": GPA_TO_BARYE
+    },
+    "real": {
+        "time": 1,
+        "pressure": GPA_TO_ATM
+    },
+    "electron": {
+        "time": 1, "pressure": GPA_TO_PA
+    },
+}
+
+
 class LammpsControl(GenericParameters):
     def __init__(self, input_file_name=None, **qwargs):
         super(LammpsControl, self).__init__(
@@ -278,22 +308,8 @@ class LammpsControl(GenericParameters):
             delta_press (float): Barostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
             job_name (str): Job name of the job to generate a unique random seed.
         """
-        # Conversion factors for transfroming pyiron units to Lammps units
-        fs_to_ps = spc.femto / spc.pico
-        fs_to_s = spc.femto / 1.0
-        GPa_to_bar = spc.giga * 1.0 / spc.bar
-        GPa_to_Pa = spc.giga
-        GPa_to_barye = spc.giga * 1.0 / (1.0e-6 * spc.bar)  # Lammps is in "barye"
-        GPa_to_atm = spc.giga * 1.0 / spc.atm
-        lammps_unit_conversions = {
-            "metal": {"time": fs_to_ps, "pressure": GPa_to_bar},
-            "si": {"time": fs_to_s, "pressure": GPa_to_Pa},
-            "cgs": {"time": fs_to_s, "pressure": GPa_to_barye},
-            "real": {"time": 1, "pressure": GPa_to_atm},
-            "electron": {"time": 1, "pressure": GPa_to_Pa},
-        }
-        time_units = lammps_unit_conversions[self["units"]]["time"]
-        pressure_units = lammps_unit_conversions[self["units"]]["pressure"]
+        time_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["time"]
+        pressure_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
         # No need for temperature conversion; pyiron and all available Lammps units are both in Kelvin
         # (well, except unitless Lennard-Jones units...)
         if self["units"] == "lj":

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -112,30 +112,32 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             warnings.warn(
                 "Warning: setting upper trangular matrix might slow down the calculation"
             )
-        if self._prism.is_skewed():
-            if self.structure._is_scaled:
-                self._interactive_lib_command(
-                    "change_box all x final 0 %f y final 0 %f z final 0 %f \
-                     xy final %f xz final %f yz final %f triclinic remap units box"
-                    % (lx, ly, lz, xy, xz, yz)
-                )
-            else:
-                self._interactive_lib_command(
-                    "change_box all x final 0 %f y final 0 %f z final 0 %f \
-                    xy final %f xz final %f yz final %f triclinic units box"
-                    % (lx, ly, lz, xy, xz, yz)
-                )
-        else:
-            if self.structure._is_scaled:
-                self._interactive_lib_command(
-                    "change_box all x final 0 %f y final 0 %f z final 0 %f remap units box"
-                    % (lx, ly, lz)
-                )
-            else:
-                self._interactive_lib_command(
-                    "change_box all x final 0 %f y final 0 %f z final 0 %f units box"
-                    % (lx, ly, lz)
-                )
+
+        is_skewed = self._prism.is_skewed()
+        is_scaled = self.structure._is_scaled
+
+        if is_skewed and is_scaled:
+            self._interactive_lib_command(
+                "change_box all x final 0 %f y final 0 %f z final 0 %f \
+                 xy final %f xz final %f yz final %f triclinic remap units box"
+                % (lx, ly, lz, xy, xz, yz)
+            )
+        elif is_skewed and not is_scaled:
+            self._interactive_lib_command(
+                "change_box all x final 0 %f y final 0 %f z final 0 %f \
+                xy final %f xz final %f yz final %f triclinic units box"
+                % (lx, ly, lz, xy, xz, yz)
+            )
+        elif not is_skewed and is_scaled:
+            self._interactive_lib_command(
+                "change_box all x final 0 %f y final 0 %f z final 0 %f remap units box"
+                % (lx, ly, lz)
+            )
+        else:  # is neither skewed nor scaled
+            self._interactive_lib_command(
+                "change_box all x final 0 %f y final 0 %f z final 0 %f units box"
+                % (lx, ly, lz)
+            )
 
     def interactive_volume_getter(self):
         return self._interactive_library.get_thermo("vol")

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -238,7 +238,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             f_tol=1e-4,
             max_iter=100000,
             pressure=None,
-            n_print=100
+            n_print=100,
+            style='cg'
     ):
         # Docstring set programmatically -- Please ensure that changes to signature or defaults stay consistent!
         if self.server.run_mode.interactive_non_modal:
@@ -251,6 +252,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             max_iter=max_iter,
             pressure=pressure,
             n_print=n_print,
+            style=style,
         )
         if self.interactive_is_activated() and (
             self.server.run_mode.interactive

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -72,13 +72,13 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             (len(self.structure), 3),
         )
         if np.matrix.trace(self._interactive_prism.R) != 3:
-            positions = np.dot(positions, self._interactive_prism.R.T)
+            positions = np.matmul(positions, self._interactive_prism.R.T)
         return positions.tolist()
 
     def interactive_positions_setter(self, positions):
         if np.matrix.trace(self._interactive_prism.R) != 3:
             positions = np.array(positions).reshape(-1, 3)
-            positions = np.dot(positions, self._interactive_prism.R)
+            positions = np.matmul(positions, self._interactive_prism.R)
         positions = np.array(positions).flatten()
         if self.server.run_mode.interactive and self.server.cores == 1:
             self._interactive_library.scatter_atoms(

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -55,6 +55,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
 
     @structure.setter
     def structure(self, structure):
+        self._prism = UnfoldingPrism(structure.cell)
         GenericInteractive.structure.fset(self, structure)
 
     def get_structure(self, iteration_step=-1, wrap_atoms=True):

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -14,6 +14,7 @@ from scipy import constants
 
 from pyiron.lammps.base import LammpsBase
 from pyiron.lammps.structure import UnfoldingPrism
+from pyiron.lammps.control import LammpsControl
 from pyiron.atomistics.job.interactive import GenericInteractive
 
 __author__ = "Osamu Waseda, Jan Janssen"
@@ -231,23 +232,14 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
         self.interactive_structure_setter(self.structure)
 
     def calc_minimize(
-        self, e_tol=0.0, f_tol=1e-4, max_iter=1000, pressure=None, n_print=100
+            self,
+            e_tol=0.0,
+            f_tol=1e-4,
+            max_iter=100000,
+            pressure=None,
+            n_print=100
     ):
-        """
-        Sets parameters required for minimisation
-
-        Args:
-            e_tol (float): If the magnitude of difference between energies of two consecutive steps is lower
-                than or equal to e_tol, the minimisation terminates and is considered converged. (Default: 0.0)
-            f_tol (float): If the magnitude of the global force vector at a step is lower than or equal to
-                f_tol, the minimisation terminates and is considered converged. (Default: 1e-4)
-            max_iter (int): Maximum number of minimisation steps to carry out. If the minimisation converges
-                before 'max_iter' steps, terminate at the converged step. If the minimisation does
-                not converge up to 'max_iter' steps, terminate at the 'max_iter' step. Default: 1000)
-            pressure (float): Pressure at which minimisation is to be carried out. If 'None', isochoric
-                (constant volume) condition will be used. (Default: None)
-            n_print (int): Write (dump or print) to the output file every n steps (Default: 100)
-        """
+        # Docstring set programmatically -- Please ensure that changes to signature or defaults stay consistent!
         if self.server.run_mode.interactive_non_modal:
             warnings.warn(
                 "calc_minimize() is not implemented for the non modal interactive mode use calc_static()!"
@@ -264,6 +256,7 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
             or self.server.run_mode.interactive_non_modal
         ):
             self.interactive_structure_setter(self.structure)
+    calc_minimize.__doc__ = LammpsControl.calc_minimize.__doc__
 
     def calc_md(
         self,

--- a/pyiron/lammps/structure.py
+++ b/pyiron/lammps/structure.py
@@ -83,9 +83,6 @@ class UnfoldingPrism(Prism):
         apre = np.array(((xhi, 0, 0), (xyp, yhi, 0), (xzp, yzp, zhi)))
         self.R = np.dot(np.linalg.inv(cell), apre)
 
-        # Actual lammps cell may be different from what is used to create R
-        eps = 1e-10
-
         def fold(vec, pvec, i):
             p = pvec[i]
             x = vec[i] + 0.5 * p
@@ -110,7 +107,7 @@ class UnfoldingPrism(Prism):
         self.ns = [n1, n2, n3]
 
         d_a = apre[0, 0] / 2 - apre[1, 0]
-        if np.abs(d_a) < eps:
+        if np.abs(d_a) < self.acc:
             if d_a < 0:
                 print("debug: apply shift")
                 apre[1, 0] += 2 * d_a

--- a/pyiron/lammps/structure.py
+++ b/pyiron/lammps/structure.py
@@ -76,7 +76,7 @@ class UnfoldingPrism(Prism):
             np.floor(np.log10(max((xhi, yhi, zhi)))) - digits
         )
         self.dir_prec = dec.Decimal("10.0") ** (-digits)
-        acc = float(self.car_prec)
+        self.acc = float(self.car_prec)
         self.eps = np.finfo(xhi).eps
 
         # For rotating positions from ase to lammps
@@ -107,7 +107,7 @@ class UnfoldingPrism(Prism):
         self.ns = [n1, n2, n3]
 
         d_a = apre[0, 0] / 2 - apre[1, 0]
-        if np.abs(d_a) < acc:
+        if np.abs(d_a) < self.acc:
             if d_a < 0:
                 print("debug: apply shift")
                 apre[1, 0] += 2 * d_a

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -38,9 +38,13 @@ class TestLammps(unittest.TestCase):
             project=ProjectHDFio(project=cls.project, file_name="lammps_vcsgc_input"),
             job_name="lammps_vcsgc_input",
         )
-        cls.control_job = Lammps(
+        cls.minimize_job = Lammps(
             project=ProjectHDFio(project=cls.project, file_name="lammps"),
-            job_name="control_lammps",
+            job_name="minimize_lammps",
+        )
+        cls.minimize_control_job = Lammps(
+            project=ProjectHDFio(project=cls.project, file_name="lammps"),
+            job_name="minimize_control_lammps",
         )
 
     @classmethod
@@ -491,21 +495,25 @@ class TestLammps(unittest.TestCase):
 
     def test_calc_minimize_input(self):
         # Ensure that defaults match control defaults
-        self.control_job.input.control.calc_minimize()
-        self.job.calc_minimize()
+        atoms = Atoms("Fe", positions=np.zeros((8, 3)), cell=np.eye(3))
+        self.minimize_control_job.structure = atoms
+        self.minimize_control_job.input.control.calc_minimize()
+
+        self.minimize_job.sturcture = atoms
+        self.minimize_job.calc_minimize()
         for k in self.job.input.control.keys():
-            self.assertEqual(self.job.input.control[k], self.control_job.input.control[k])
+            self.assertEqual(self.minimize_job.input.control[k], self.minimize_control_job.input.control[k])
 
         # Ensure that pressure inputs are being parsed OK
-        self.control_job.calc_minimize(pressure=0)
+        self.minimize_control_job.calc_minimize(pressure=0)
         self.assertEqual(
-            self.control_job.input.control['fix___ensemble'],
+            self.minimize_control_job.input.control['fix___ensemble'],
             "all box/relax x 0.0 y 0.0 z 0.0 couple none"
         )
 
-        self.control_job.calc_minimize(pressure=[1, 2, None, 0., 0., None])
+        self.minimize_control_job.calc_minimize(pressure=[1, 2, None, 0., 0., None])
         self.assertEqual(
-            self.control_job.input.control['fix___ensemble'],
+            self.minimize_control_job.input.control['fix___ensemble'],
             "all box/relax x 10000.0 y 20000.0 xy 0.0 xz 0.0 couple none"
         )
 

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -413,32 +413,37 @@ class TestLammps(unittest.TestCase):
         bad_element = {s: 0. for s in symbols}
         bad_element.update({'X': 1.})  # Non-existant chemical symbol
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, mu=bad_element
+            ValueError, self.job_vcsgc_input.calc_vcsgc, mu=bad_element, temperature_mc=300.
         )
 
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, target_concentration=bad_element
+            ValueError, self.job_vcsgc_input.calc_vcsgc, target_concentration=bad_element, temperature_mc=300.
         )
 
         bad_conc = {s: 0. for s in symbols}
         bad_conc['Al'] = 0.99
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, target_concentration=bad_conc
+            ValueError, self.job_vcsgc_input.calc_vcsgc, target_concentration=bad_conc, temperature_mc=300.
         )
 
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, window_moves=-1
+            ValueError, self.job_vcsgc_input.calc_vcsgc, window_moves=-1, temperature_mc=300.
         )
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, window_moves=1.1
+            ValueError, self.job_vcsgc_input.calc_vcsgc, window_moves=1.1, temperature_mc=300.
         )
 
         self.assertRaises(
-            ValueError, self.job_vcsgc_input.calc_vcsgc, window_size=0.3
+            ValueError, self.job_vcsgc_input.calc_vcsgc, window_size=0.3, temperature_mc=300.
         )
 
         mu = {s: 0. for s in symbols}
         mu[symbols[0]] = 1.
+        self.assertRaises(
+            ValueError, self.job_vcsgc_input.calc_vcsgc, mu=mu, temperature_mc=None, temperature=None
+        )
+
+
         args = dict(
             mu=mu,
             target_concentration=None,
@@ -449,7 +454,7 @@ class TestLammps(unittest.TestCase):
             window_size=None,
             window_moves=None,
             seed=1,
-            temperature=300,
+            temperature=300.0,
         )
         input_string = 'all sgcmc {0} {1} {2} {3} randseed {4}'.format(
             args['mc_step_interval'],

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -25,21 +25,31 @@ class InteractiveLibrary(object):
 class TestLammpsInteractive(unittest.TestCase):
     def setUp(self):
         self.job._interactive_library = InteractiveLibrary()
+        self.control_job._interactive_library = InteractiveLibrary()
 
     @classmethod
     def setUpClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         cls.project = Project(os.path.join(cls.execution_path, "lammps"))
+
+        structure = Atoms(
+            symbols="Fe2",
+            positions=np.outer(np.arange(2), np.ones(3)),
+            cell=2 * np.eye(3),
+        )
+
         cls.job = Lammps(
             project=ProjectHDFio(project=cls.project, file_name="lammps"),
             job_name="lammps",
         )
         cls.job.server.run_mode.interactive = True
-        cls.job.structure = Atoms(
-            symbols="Fe2",
-            positions=np.outer(np.arange(2), np.ones(3)),
-            cell=2 * np.eye(3),
+        cls.job.structure = structure
+
+        cls.control_job = Lammps(
+            project=ProjectHDFio(project=cls.project, file_name="lammps"),
+            job_name="control_lammps",
         )
+        # cls.control_job.server.run_mode.interactive = True  # Fails if we then call, e.g. `calc_minimize`
 
     @classmethod
     def tearDownClass(cls):
@@ -74,6 +84,29 @@ class TestLammpsInteractive(unittest.TestCase):
                 "thermo 100",
             ],
         )
+
+    def test_calc_minimize_input(self):
+        # Ensure defaults match control
+        self.job.input.control.calc_minimize()
+        self.job._interactive_lammps_input()
+        self.control_job.calc_minimize()
+        self.control_job._interactive_lammps_input()
+
+        self.assertEqual(
+            self.job._interactive_library._command,
+            self.control_job._interactive_library._command
+        )
+
+        # Ensure that pressure inputs are being parsed OK
+        self.control_job.calc_minimize(pressure=0)
+        self.control_job._interactive_lammps_input()
+        self.assertTrue(("fix ensemble all box/relax x 0.0 y 0.0 z 0.0 couple none" in
+                         self.control_job._interactive_library._command))
+
+        self.control_job.calc_minimize(pressure=[1, 2, None, 0., 0., None])
+        self.control_job._interactive_lammps_input()
+        self.assertTrue(("fix ensemble all box/relax x 10000.0 y 20000.0 xy 0.0 xz 0.0 couple none" in
+                         self.control_job._interactive_library._command))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Key features:

- Convert to and from triclinic cells for Lammps
- Allow non-diagonal pressures (i.e. Pxy, Pxz, and Pyz) during Lammps relaxation and minimization
- Fun extra: synchronized `calc_minimize` docstrings to a single place then linked it in other places (plus tests to make sure the defaults stay validly described)

I had originally intended just to get triclinic cells working, e.g. for running primitive cells (there was a conversion in place but it had a bug), but wound up implementing a more complete binding to cell shape changes.