### PR TITLE
Enmax finder

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -83,7 +83,7 @@ class VaspBase(GenericDFTJob):
         self._output_parser = Output()
         self._potential = VaspPotentialSetter([])
         self._compress_by_default = True
-        self.get_enmax_among_species
+        self.get_enmax_among_species = get_enmax_among_species
         s.publication_add(self.publication)
 
     @property

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -5,13 +5,11 @@
 from __future__ import print_function
 import os
 import posixpath
-from shutil import copyfile
 import subprocess
 import numpy as np
-import tables
 
 from pyiron.dft.job.generic import GenericDFTJob
-from pyiron.vasp.potential import VaspPotential, VaspPotentialFile, VaspPotentialSetter
+from pyiron.vasp.potential import VaspPotential, VaspPotentialFile, VaspPotentialSetter, Potcar
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
 from pyiron.base.settings.generic import Settings
 from pyiron.base.generic.parameters import GenericParameters
@@ -22,7 +20,7 @@ from pyiron.vasp.structure import read_atoms, write_poscar, vasp_sorter
 from pyiron.vasp.vasprun import Vasprun as Vr
 from pyiron.vasp.vasprun import VasprunError
 from pyiron.vasp.volumetric_data import VaspVolumetricData
-from pyiron.vasp.potential import find_potential_file, get_enmax_among_species
+from pyiron.vasp.potential import get_enmax_among_species
 from pyiron.dft.waves.electronic import ElectronicStructure
 from pyiron.dft.waves.bandstructure import Bandstructure
 import warnings
@@ -2179,153 +2177,6 @@ Monkhorst_Pack
                     kspace_per_in_ang=self._dataset["density_of_mesh"],
                 )
                 self.set(size_of_mesh=k_mesh)
-
-
-class Potcar(GenericParameters):
-    pot_path_dict = {"GGA": "paw-gga-pbe", "PBE": "paw-gga-pbe", "LDA": "paw-lda"}
-
-    def __init__(self, input_file_name=None, table_name="potcar"):
-        GenericParameters.__init__(
-            self,
-            input_file_name=input_file_name,
-            table_name=table_name,
-            val_only=False,
-            comment_char="#",
-        )
-        self._structure = None
-        self.electrons_per_atom_lst = list()
-        self.max_cutoff_lst = list()
-        self.el_path_lst = list()
-        self.el_path_dict = dict()
-        self.modified_elements = dict()
-
-    def potcar_set_structure(self, structure, modified_elements):
-        self._structure = structure
-        self._set_default_path_dict()
-        self._set_potential_paths()
-        self.modified_elements = modified_elements
-
-    def modify(self, **modify):
-        if "xc" in modify:
-            xc_type = modify["xc"]
-            self._set_default_path_dict()
-            if xc_type not in self.pot_path_dict:
-                raise ValueError("xc type not implemented: " + xc_type)
-        GenericParameters.modify(self, **modify)
-        if self._structure is not None:
-            self._set_potential_paths()
-
-    def _set_default_path_dict(self):
-        if self._structure is None:
-            return
-        vasp_potentials = VaspPotentialFile(xc=self.get("xc"))
-        for i, el_obj in enumerate(self._structure.get_species_objects()):
-            if isinstance(el_obj.Parent, str):
-                el = el_obj.Parent
-            else:
-                el = el_obj.Abbreviation
-            if isinstance(el_obj.tags, dict):
-                if "pseudo_potcar_file" in el_obj.tags.keys():
-                    new_element = el_obj.tags["pseudo_potcar_file"]
-                    vasp_potentials.add_new_element(
-                        parent_element=el, new_element=new_element
-                    )
-            key = vasp_potentials.find_default(el).Species.values[0][0]
-            val = vasp_potentials.find_default(el).Name.values[0]
-            self[key] = val
-
-    def _set_potential_paths(self):
-        element_list = (
-            self._structure.get_species_symbols()
-        )  # .ElementList.getSpecies()
-        object_list = self._structure.get_species_objects()
-        s.logger.debug("element list: {0}".format(element_list))
-        self.el_path_lst = list()
-        try:
-            xc = self.get("xc")
-        except tables.exceptions.NoSuchNodeError:
-            xc = self.get("xc")
-        s.logger.debug("XC: {0}".format(xc))
-        vasp_potentials = VaspPotentialFile(xc=xc)
-        for i, el_obj in enumerate(object_list):
-            if isinstance(el_obj.Parent, str):
-                el = el_obj.Parent
-            else:
-                el = el_obj.Abbreviation
-            if (
-                isinstance(el_obj.tags, dict)
-                and "pseudo_potcar_file" in el_obj.tags.keys()
-            ):
-                new_element = el_obj.tags["pseudo_potcar_file"]
-                vasp_potentials.add_new_element(
-                    parent_element=el, new_element=new_element
-                )
-                el_path = find_potential_file(
-                    path=vasp_potentials.find_default(new_element)["Filename"].values[
-                        0
-                    ][0],
-                    pot_path_dict=self.pot_path_dict,
-                )
-                if not (os.path.isfile(el_path)):
-                    raise ValueError("such a file does not exist in the pp directory")
-            else:
-                el_path = find_potential_file(
-                    path=vasp_potentials.find_default(el)["Filename"].values[0][0],
-                    pot_path_dict=self.pot_path_dict,
-                )
-
-            if not (os.path.isfile(el_path)):
-                raise AssertionError()
-            pot_name = "pot_" + str(i)
-
-            if pot_name in self._dataset["Parameter"]:
-                try:
-                    ind = self._dataset["Parameter"].index(pot_name)
-                except (ValueError, IndexError):
-                    indices = np.core.defchararray.find(
-                        self._dataset["Parameter"], pot_name
-                    )
-                    ind = np.where(indices == 0)[0][0]
-                self._dataset["Value"][ind] = el_path
-                self._dataset["Comment"][ind] = ""
-            else:
-                self._dataset["Parameter"].append("pot_" + str(i))
-                self._dataset["Value"].append(el_path)
-                self._dataset["Comment"].append("")
-            if el_obj.Abbreviation in self.modified_elements.keys():
-                self.el_path_lst.append(self.modified_elements[el_obj.Abbreviation])
-            else:
-                self.el_path_lst.append(el_path)
-
-    def write_file(self, file_name, cwd=None):
-        """
-        Args:
-            file_name:
-            cwd:
-        Returns:
-        """
-        self.electrons_per_atom_lst = list()
-        self.max_cutoff_lst = list()
-        self._set_potential_paths()
-        if cwd is not None:
-            file_name = posixpath.join(cwd, file_name)
-        f = open(file_name, "w")
-        for el_file in self.el_path_lst:
-            with open(el_file) as pot_file:
-                for i, line in enumerate(pot_file):
-                    f.write(line)
-                    if i == 1:
-                        self.electrons_per_atom_lst.append(int(float(line)))
-                    elif i == 14:
-                        mystr = line.split()[2][:-1]
-                        self.max_cutoff_lst.append(float(mystr))
-        f.close()
-
-    def load_default(self):
-        file_content = """\
-xc  GGA  # LDA, GGA
-"""
-        self.load_string(file_content)
 
 
 def get_k_mesh_by_cell(cell, kspace_per_in_ang=0.10):

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -22,7 +22,7 @@ from pyiron.vasp.structure import read_atoms, write_poscar, vasp_sorter
 from pyiron.vasp.vasprun import Vasprun as Vr
 from pyiron.vasp.vasprun import VasprunError
 from pyiron.vasp.volumetric_data import VaspVolumetricData
-from pyiron.vasp.potential import find_potential_file
+from pyiron.vasp.potential import find_potential_file, get_enmax_among_species
 from pyiron.dft.waves.electronic import ElectronicStructure
 from pyiron.dft.waves.bandstructure import Bandstructure
 import warnings
@@ -83,6 +83,7 @@ class VaspBase(GenericDFTJob):
         self._output_parser = Output()
         self._potential = VaspPotentialSetter([])
         self._compress_by_default = True
+        self.get_enmax_among_species
         s.publication_add(self.publication)
 
     @property

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -274,12 +274,12 @@ def find_potential_file(file_name=None, xc=None, path=None, pot_path_dict=None):
     raise ValueError("Either the filename or the functional has to be defined.")
 
 
-def get_enmax_among_species(species_lst, return_list=False, xc="PBE"):
+def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
     """
     Given a list of species symbols, finds the largest applicable encut.
 
     Args:
-        species_lst (list): The list of species symbols.
+        symbol_lst (list): The list of species symbols.
         return_list (bool): Whether to return the list of all ENMAX values (in the same order as `species_lst` along with
             the largest value). (Default is False.)
         xc ("GGA"/"PBE"/"LDA"): The exchange correlation functional for which the POTCARs were generated. (Default is "PBE".)
@@ -294,7 +294,7 @@ def get_enmax_among_species(species_lst, return_list=False, xc="PBE"):
     enmax_lst = []
     vpf = VaspPotentialFile(xc=xc)
 
-    for symbol in species_lst:
+    for symbol in symbol_lst:
         potcar_file = find_potential_file(
             path=vpf.find_default(symbol)['Filename'].values[0][0],
             pot_path_dict=pot_path_dict

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -11,7 +11,6 @@ import tables
 from pyiron.base.generic.parameters import GenericParameters
 from pyiron.base.settings.generic import Settings
 from pyiron.atomistics.job.potentials import PotentialAbstract
-from pyiron.vasp.base import s
 
 __author__ = "Jan Janssen"
 __copyright__ = (

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -3,7 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
-from os import path
+import posixpath
 
 import numpy as np
 import pandas

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -6,7 +6,6 @@ import os
 import pandas
 from pyiron.base.settings.generic import Settings
 from pyiron.atomistics.job.potentials import PotentialAbstract
-from pyiron.vasp.base import Potcar
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -289,13 +288,16 @@ def get_enmax_among_species(species_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
+    from pyiron.vasp.base import Potcar
+    pot_path_dict = Potcar.pot_path_dict
+
     enmax_lst = []
     vpf = VaspPotentialFile(xc=xc)
 
     for symbol in species_lst:
         potcar_file = find_potential_file(
             path=vpf.find_default(symbol)['Filename'].values[0][0],
-            pot_path_dict=Potcar.pot_path_dict
+            pot_path_dict=pot_path_dict
         )
         with open(potcar_file) as pf:
             for i, line in enumerate(pf):

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -3,9 +3,15 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import os
+from os import path
+
+import numpy as np
 import pandas
+import tables
+from pyiron.base.generic.parameters import GenericParameters
 from pyiron.base.settings.generic import Settings
 from pyiron.atomistics.job.potentials import PotentialAbstract
+from pyiron.vasp.base import s
 
 __author__ = "Jan Janssen"
 __copyright__ = (
@@ -288,7 +294,6 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
-    from pyiron.vasp.base import Potcar
     pot_path_dict = Potcar.pot_path_dict
 
     enmax_lst = []
@@ -310,3 +315,150 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         return max(enmax_lst), enmax_lst
     else:
         return max(enmax_lst)
+
+
+class Potcar(GenericParameters):
+    pot_path_dict = {"GGA": "paw-gga-pbe", "PBE": "paw-gga-pbe", "LDA": "paw-lda"}
+
+    def __init__(self, input_file_name=None, table_name="potcar"):
+        GenericParameters.__init__(
+            self,
+            input_file_name=input_file_name,
+            table_name=table_name,
+            val_only=False,
+            comment_char="#",
+        )
+        self._structure = None
+        self.electrons_per_atom_lst = list()
+        self.max_cutoff_lst = list()
+        self.el_path_lst = list()
+        self.el_path_dict = dict()
+        self.modified_elements = dict()
+
+    def potcar_set_structure(self, structure, modified_elements):
+        self._structure = structure
+        self._set_default_path_dict()
+        self._set_potential_paths()
+        self.modified_elements = modified_elements
+
+    def modify(self, **modify):
+        if "xc" in modify:
+            xc_type = modify["xc"]
+            self._set_default_path_dict()
+            if xc_type not in self.pot_path_dict:
+                raise ValueError("xc type not implemented: " + xc_type)
+        GenericParameters.modify(self, **modify)
+        if self._structure is not None:
+            self._set_potential_paths()
+
+    def _set_default_path_dict(self):
+        if self._structure is None:
+            return
+        vasp_potentials = VaspPotentialFile(xc=self.get("xc"))
+        for i, el_obj in enumerate(self._structure.get_species_objects()):
+            if isinstance(el_obj.Parent, str):
+                el = el_obj.Parent
+            else:
+                el = el_obj.Abbreviation
+            if isinstance(el_obj.tags, dict):
+                if "pseudo_potcar_file" in el_obj.tags.keys():
+                    new_element = el_obj.tags["pseudo_potcar_file"]
+                    vasp_potentials.add_new_element(
+                        parent_element=el, new_element=new_element
+                    )
+            key = vasp_potentials.find_default(el).Species.values[0][0]
+            val = vasp_potentials.find_default(el).Name.values[0]
+            self[key] = val
+
+    def _set_potential_paths(self):
+        element_list = (
+            self._structure.get_species_symbols()
+        )  # .ElementList.getSpecies()
+        object_list = self._structure.get_species_objects()
+        s.logger.debug("element list: {0}".format(element_list))
+        self.el_path_lst = list()
+        try:
+            xc = self.get("xc")
+        except tables.exceptions.NoSuchNodeError:
+            xc = self.get("xc")
+        s.logger.debug("XC: {0}".format(xc))
+        vasp_potentials = VaspPotentialFile(xc=xc)
+        for i, el_obj in enumerate(object_list):
+            if isinstance(el_obj.Parent, str):
+                el = el_obj.Parent
+            else:
+                el = el_obj.Abbreviation
+            if (
+                isinstance(el_obj.tags, dict)
+                and "pseudo_potcar_file" in el_obj.tags.keys()
+            ):
+                new_element = el_obj.tags["pseudo_potcar_file"]
+                vasp_potentials.add_new_element(
+                    parent_element=el, new_element=new_element
+                )
+                el_path = find_potential_file(
+                    path=vasp_potentials.find_default(new_element)["Filename"].values[
+                        0
+                    ][0],
+                    pot_path_dict=self.pot_path_dict,
+                )
+                if not (os.path.isfile(el_path)):
+                    raise ValueError("such a file does not exist in the pp directory")
+            else:
+                el_path = find_potential_file(
+                    path=vasp_potentials.find_default(el)["Filename"].values[0][0],
+                    pot_path_dict=self.pot_path_dict,
+                )
+
+            if not (os.path.isfile(el_path)):
+                raise AssertionError()
+            pot_name = "pot_" + str(i)
+
+            if pot_name in self._dataset["Parameter"]:
+                try:
+                    ind = self._dataset["Parameter"].index(pot_name)
+                except (ValueError, IndexError):
+                    indices = np.core.defchararray.find(
+                        self._dataset["Parameter"], pot_name
+                    )
+                    ind = np.where(indices == 0)[0][0]
+                self._dataset["Value"][ind] = el_path
+                self._dataset["Comment"][ind] = ""
+            else:
+                self._dataset["Parameter"].append("pot_" + str(i))
+                self._dataset["Value"].append(el_path)
+                self._dataset["Comment"].append("")
+            if el_obj.Abbreviation in self.modified_elements.keys():
+                self.el_path_lst.append(self.modified_elements[el_obj.Abbreviation])
+            else:
+                self.el_path_lst.append(el_path)
+
+    def write_file(self, file_name, cwd=None):
+        """
+        Args:
+            file_name:
+            cwd:
+        Returns:
+        """
+        self.electrons_per_atom_lst = list()
+        self.max_cutoff_lst = list()
+        self._set_potential_paths()
+        if cwd is not None:
+            file_name = posixpath.join(cwd, file_name)
+        f = open(file_name, "w")
+        for el_file in self.el_path_lst:
+            with open(el_file) as pot_file:
+                for i, line in enumerate(pot_file):
+                    f.write(line)
+                    if i == 1:
+                        self.electrons_per_atom_lst.append(int(float(line)))
+                    elif i == 14:
+                        mystr = line.split()[2][:-1]
+                        self.max_cutoff_lst.append(float(mystr))
+        f.close()
+
+    def load_default(self):
+        file_content = """\
+xc  GGA  # LDA, GGA
+"""
+        self.load_string(file_content)

--- a/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
+++ b/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
@@ -1,15 +1,15 @@
-# This
-# Is
-# Not
-# A
-# Real
-# POTCAR
-# File
-# Because
-# We
-# Don't
-# Have
-# The
-# Rights
+# This is not a real POTCAR file because we don't have the rights to upload those
+   8.00000000000000
 # Just edit it with fake content to meet your testing needs
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
+#
    ENMAX  =  42.0; ENMIN  =  41.99999 eV

--- a/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
+++ b/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
@@ -1,9 +1,15 @@
-Poscar file generated with pyCMW
-1.0
-2.800000 0.000000 0.000000
-0.000000 2.800000 0.000000
-0.000000 0.000000 2.800000
-2 
-Direct
-0.000000000000000 0.000000000000000 0.000000000000000
-0.500000000000000 0.500000000000000 0.500000000000000
+# This
+# Is
+# Not
+# A
+# Real
+# POTCAR
+# File
+# Because
+# We
+# Don't
+# Have
+# The
+# Rights
+   ENMAX  =  42.0; ENMIN  =  41.99999 eV
+# Just edit it with fake content to meet your testing needs

--- a/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
+++ b/tests/static/vasp/potentials/potpaw_PBE/Fe/POTCAR
@@ -11,5 +11,5 @@
 # Have
 # The
 # Rights
-   ENMAX  =  42.0; ENMIN  =  41.99999 eV
 # Just edit it with fake content to meet your testing needs
+   ENMAX  =  42.0; ENMIN  =  41.99999 eV

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -14,14 +14,14 @@ class TestPotential(unittest.TestCase):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
 
     def test_get_enmax_among_species(self):
-        float_out = get_enmax_among_species(['Al'], return_list=False)
+        float_out = get_enmax_among_species(['Fe'], return_list=False)
         self.assertTrue(isinstance(float_out, float))
 
-        tuple_out = get_enmax_among_species(['Al'], return_list=True)
+        tuple_out = get_enmax_among_species(['Fe'], return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
         self.assertRaises(KeyError, get_enmax_among_species, species_lst=['X'])
-        self.assertRaises(ValueError, get_enmax_among_species, species_lst=['Al'], xc='FOO')
+        self.assertRaises(ValueError, get_enmax_among_species, species_lst=['Fe'], xc='FOO')
 
 
 if __name__ == "__main__":

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+import os
+from pyiron.vasp.potential import get_enmax_among_species
+
+
+class TestPotential(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
+
+    def test_get_enmax_among_species(self):
+        float_out = get_enmax_among_species(['Al'], return_list=False)
+        self.assertTrue(isinstance(float_out, float))
+
+        tuple_out = get_enmax_among_species(['Al'], return_list=True)
+        self.assertTrue(isinstance(tuple_out, tuple))
+
+        self.assertRaises(KeyError, get_enmax_among_species, species_lst=['X'])
+        self.assertRaises(ValueError, get_enmax_among_species, species_lst=['Al'], xc='FOO')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -20,8 +20,8 @@ class TestPotential(unittest.TestCase):
         tuple_out = get_enmax_among_species(['Fe'], return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
-        self.assertRaises(KeyError, get_enmax_among_species, species_lst=['X'])
-        self.assertRaises(ValueError, get_enmax_among_species, species_lst=['Fe'], xc='FOO')
+        self.assertRaises(KeyError, get_enmax_among_species, symbol_lst=['X'])
+        self.assertRaises(ValueError, get_enmax_among_species, symbol_lst=['Fe'], xc='FOO')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The [VASP wiki](https://www.vasp.at/wiki/index.php/ENCUT) states 

> For consistency reasons we still recommend to specify the cutoff manually in the INCAR file and keep it constant throughout a set of calculations.

e.g. if you're looking at the segregation of various solutes to a particular defect, then you should use the highest ENCUT among host and all solutes across all calculations, even that of your pure-host defect. 

Thus, it's nice to be able to quickly assess what that cutoff value is for a given set of elements. 