### PR TITLE
sphinx restart 

### DIFF
--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -336,6 +336,12 @@ class SphinxBase(GenericDFTJob):
         from_charge_density=True,
         from_wave_functions=True,
     ):
+        if self.status!='finished':
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                self.collect_output()
+                if len(w) > 0:
+                    self.status.not_converged = True
         new_job = super(SphinxBase, self).restart(
             snapshot=snapshot, job_name=job_name, job_type=job_type
         )


### PR DESCRIPTION
SPHInX can now be relaunched when a simulation does not converge within the allocated computation time (e.g. 4 days). It had already been possible to create a restart job by `job.restart()`, but it did not reflect the final results automatically (i.e. the output files of the not converged simulation were not parsed). With this fix, a single  `job.restart()` will parse the output files of the not-converged simulation **and** it sets the status to `not_converged` (instead of `aborted` which had been the case before).