### PR TITLE
enable in Project().remove() has to be set explicitly to True

### DIFF
--- a/pyiron/base/project/generic.py
+++ b/pyiron/base/project/generic.py
@@ -1032,7 +1032,7 @@ class Project(ProjectPath):
             enforce (bool): [True/False] delete jobs even though they are used in other projects - default=False
             enable (bool): [True/False] enable this command.
         """
-        if not enable:
+        if enable is not True:
             raise ValueError(
                 "To prevent users from accidentally deleting files - enable has to be set to True."
             )


### PR DESCRIPTION
enable in Project().remove() now has to be explicitly set to True in order for the project to be deleted. I'm doing this because I sometimes write `remove()` instead of `remove_job()`, where I write a job name, which enacted `remove()` because `if job_name` was True.