### PR TITLE
Interactive input speedup

### DIFF
--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -165,7 +165,10 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
             rtol=1e-15, atol=1e-15,
         ):
             self._logger.debug("Generic library: cell changed!")
-            self.interactive_cells_setter(self._structure_current.cell)
+            try:
+                self.interactive_cells_setter(self._structure_current.cell)
+            except NotImplementedError:
+                del self.interactive_input_functions['cell']
 
     def interactive_positions_organizer(self):
         if not np.allclose(

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -201,12 +201,15 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
         del_key_lst = []
         for k,v in self.interactive_output_functions.items():
             try:
-                self.interactive_cache[k].append(v())
+                value = v()
+                if value is not None:
+                    self.interactive_cache[k].append(value)
+                else:
+                    del_key_lst.append(k)
             except NotImplementedError:
                 del_key_lst.append(k)
         for k in del_key_lst:
             del self.interactive_output_functions[k]
-            del self.interactive_cache[k]
         if (
             len(list(self.interactive_cache.keys())) > 0
             and len(self.interactive_cache[list(self.interactive_cache.keys())[0]])

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -181,7 +181,7 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
             self.interactive_positions_setter(self._structure_current.positions)
 
     def interactive_magmom_organizer(self):
-        if np.all(self._structure_current.get_initial_magnetic_moments()==None):
+        if all(mm is None for mm in self._structure_current.get_initial_magnetic_moments()):
             del self.interactive_input_functions['magnetic_moments']
         elif (None in self._structure_previous.get_initial_magnetic_moments()
             or not np.allclose(

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -181,7 +181,7 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
             self.interactive_positions_setter(self._structure_current.positions)
 
     def interactive_magmom_organizer(self):
-        if all(self._structure_current.get_initial_magnetic_moments()==None):
+        if np.all(self._structure_current.get_initial_magnetic_moments()==None):
             del self.interactive_input_functions['magnetic_moments']
         elif (None in self._structure_previous.get_initial_magnetic_moments()
             or not np.allclose(

--- a/pyiron/sphinx/interactive.py
+++ b/pyiron/sphinx/interactive.py
@@ -84,9 +84,6 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
         self._coarse_run = value
         self.input["CoarseRun"] = self._coarse_run
 
-    def interactive_cells_setter(self, cell):
-        warnings.warn("cell size cannot be changed in SPHInX; function ignored")
-
     def interactive_cells_getter(self):
         self._interactive_pipe_write("get cell")
         cc = []

--- a/tests/sphinx/test_interactive.py
+++ b/tests/sphinx/test_interactive.py
@@ -104,10 +104,8 @@ class TestSphinx(unittest.TestCase):
         os.rmdir(os.path.join(cls.file_location, "../static/sphinx/job_sphinx_hdf5"))
 
     def test_interactive_cells_setter(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertRaises(NotImplementedError) as c:
             self.sphinx.interactive_cells_setter(np.eye(3))
-            self.assertEqual(len(w), 1)
 
     def test_coarse_run(self):
         self.assertFalse(self.sphinx.coarse_run)

--- a/tests/sphinx/test_interactive.py
+++ b/tests/sphinx/test_interactive.py
@@ -104,7 +104,7 @@ class TestSphinx(unittest.TestCase):
         os.rmdir(os.path.join(cls.file_location, "../static/sphinx/job_sphinx_hdf5"))
 
     def test_interactive_cells_setter(self):
-        with self.assertRaises(NotImplementedError) as c:
+        with self.assertRaises(NotImplementedError):
             self.sphinx.interactive_cells_setter(np.eye(3))
 
     def test_coarse_run(self):


### PR DESCRIPTION
Now the input has essentially the same structure. This has two important implications:

1. It can be made faster (up to 4 times, combined with the output stuff)
2. If the input is not defined (e.g. cell in DFT), it can be removed beforehand, which allows for a more secure input handling.

I add a notebook that I used for testing:

[interactive_speedup.ipynb.txt](https://github.com/pyiron/pyiron/files/4026409/interactive_speedup.ipynb.txt)
