### PR TITLE
Drop Python 2.7 tests in favour of Python 3.8 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,10 @@ jobs:
     vmImage: $(linux)
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 4
 
   steps:
@@ -30,10 +30,10 @@ jobs:
     vmImage: $(mac)
   strategy:
     matrix:
-      Python27:
-        python.version: '2.7'
       Python37:
         python.version: '3.7'
+      Python38:
+        python.version: '3.8'
     maxParallel: 1
 
   steps:


### PR DESCRIPTION
Currently only on Azure 