### PR TITLE
Fix for SerialMaster

### DIFF
--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -172,10 +172,6 @@ class GenericJob(JobCore):
             signal.signal(sig, self.signal_intercept)
 
     @property
-    def python_execution_process(self):
-        return self._process
-
-    @property
     def version(self):
         """
         Get the version of the hamiltonian, which is also the version of the executable unless a custom executable is

--- a/pyiron/base/master/serial.py
+++ b/pyiron/base/master/serial.py
@@ -360,9 +360,8 @@ class SerialMasterBase(GenericMaster):
         job.run()
 
     def _run_if_master_queue(self, job):
+        job.server.run_mode.modal = True
         job.run()
-        if job.python_execution_process:
-            job.python_execution_process.communicate()
         self.run_if_refresh()
 
     def _run_if_master_non_modal_child_non_modal(self, job):


### PR DESCRIPTION
Enforce run_mode modal when submitting to the queue - it is important that the master process never stops, otherwise the queuing system is going to kill the job. At least modern queuing systems like Slurm do. @sudarsan-surendralal this should fix your issue with the SerialMaster.  