### PR TITLE
Fix _setitem__

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2837,19 +2837,24 @@ class Atoms(object):
                     if len(key) == 0:
                         return
             else:
-                if key.start is not None:
-                    if key.stop is not None:
-                        key = np.arange(key.start, key.stop, key.step)
-                    else:
-                        if key.start >= 0:
-                            key = np.arange(key.start, len(self), key.step)
-                        else:
-                            key = np.arange(len(self) + key.start, len(self), key.step)
+                # Generating the correct numpy array from a slice input
+                if key.start is None:
+                    start_val = 0
+                elif key.start < 0:
+                    start_val = key.start + len(self)
                 else:
-                    if key.stop is not None:
-                        key = np.arange(0, key.stop, key.step)
-                    else:
-                        key = np.arange(0, len(self), key.step)
+                    start_val = key.start
+                if key.stop is None:
+                    stop_val = len(self)
+                elif key.stop < 0:
+                    stop_val = key.stop + len(self)
+                else:
+                    stop_val = key.stop
+                if key.step is None:
+                    step_val = 1
+                else:
+                    step_val = key.step
+                key = np.arange(start_val, stop_val, step_val)
             if isinstance(value, (str, np.str, np.str_, int, np.integer)):
                 el = PeriodicTable().element(value)
             elif isinstance(value, ChemicalElement):

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2865,6 +2865,7 @@ class Atoms(object):
                 )
             replace_list = list()
             new_species = list(np.array(self.species).copy())
+
             for sp in self.species:
                 replace_list.append(
                     np.array_equal(
@@ -2899,7 +2900,7 @@ class Atoms(object):
                         if i != ind and rep:
                             delete_indices.append(i)
                             # del new_species[i]
-                            new_indices[new_indices > i] -= 1
+                            new_indices[new_indices >= i] -= 1
                     self.indices = new_indices.copy()
                     new_species = np.array(new_species)[
                         np.setdiff1d(np.arange(len(new_species)), delete_indices)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -266,6 +266,7 @@ class TestAtoms(unittest.TestCase):
             len(basis_new._tag_list), len(basis[mg_indices]) + len(basis[o_indices])
         )
         self.assertEqual(basis_new.get_spacegroup()["Number"], 225)
+        self.assertEqual(basis[:-3], basis[0:len(basis)-4])
 
     def test_positions(self):
         self.assertEqual(self.CO2[1:].positions[1:].tolist(), [[0.0, 1.5, 0.0]])
@@ -1264,6 +1265,18 @@ class TestAtoms(unittest.TestCase):
         lat_1.set_scaled_positions(1 / 4 + lat_1.get_scaled_positions())
         lat_1[:] = "V"  # vacancies
         self.assertEqual(lat_1.get_chemical_formula(), "V108")
+        basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)
+        basis_Mg.set_repeat(3)
+        basis_Mg[:-3] = "Al"
+        self.assertEqual(basis_Mg.get_chemical_formula(), 'Al105Mg3')
+        basis_Mg[4:-len(basis_Mg)+7] = "C"
+        self.assertEqual(basis_Mg.get_chemical_formula(), 'Al102C3Mg3')
+        basis_Mg[4:] = "C"
+        self.assertEqual(basis_Mg.get_chemical_formula(), 'Al4C104')
+        basis_Mg[:] = "Mg"
+        self.assertEqual(basis_Mg.get_chemical_formula(), 'Mg108')
+        basis_Mg[0:-1:2] = "Al"
+        self.assertEqual(basis_Mg.get_chemical_formula(), 'Al54Mg54')
 
 
 def generate_fcc_lattice(a=4.2):

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1275,8 +1275,39 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(basis_Mg.get_chemical_formula(), 'Al4C104')
         basis_Mg[:] = "Mg"
         self.assertEqual(basis_Mg.get_chemical_formula(), 'Mg108')
-        basis_Mg[0:-1:2] = "Al"
+        basis_Mg[::2] = "Al"
         self.assertEqual(basis_Mg.get_chemical_formula(), 'Al54Mg54')
+        struct = CrystalStructure("Al", bravais_basis="fcc", lattice_constant=4.2, bravais_lattice="cubic")
+        struct[0] = 'Mg'
+        self.assertEqual(struct.get_chemical_formula(), 'Al3Mg')
+        struct[1] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Al2CuMg')
+        struct[0] = 'Cu'
+        struct[1] = 'Cu'
+        struct[2] = 'Cu'
+        struct[3] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Cu4')
+        struct = CrystalStructure("Al", bravais_basis="fcc", lattice_constant=4.2, bravais_lattice="cubic")
+        struct[0] = 'Mg'
+        self.assertEqual(struct.get_chemical_formula(), 'Al3Mg')
+        struct[1] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Al2CuMg')
+        struct[0:] = 'N'
+        self.assertEqual(struct.get_chemical_formula(), 'N4')
+        struct = CrystalStructure("Al", bravais_basis="fcc", lattice_constant=4.2, bravais_lattice="cubic")
+        struct[0] = 'Mg'
+        self.assertEqual(struct.get_chemical_formula(), 'Al3Mg')
+        struct[1] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Al2CuMg')
+        struct[0:] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Cu4')
+        struct = CrystalStructure("Al", bravais_basis="fcc", lattice_constant=4.2, bravais_lattice="cubic")
+        struct[0] = 'Mg'
+        self.assertEqual(struct.get_chemical_formula(), 'Al3Mg')
+        struct[1] = 'Cu'
+        self.assertEqual(struct.get_chemical_formula(), 'Al2CuMg')
+        struct[0:] = 'Mg'
+        self.assertEqual(struct.get_chemical_formula(), 'Mg4')
 
 
 def generate_fcc_lattice(a=4.2):


### PR DESCRIPTION
Two issues are fixed in this pull request based on this issue https://github.com/pyiron/pyiron/issues/542

- The correct implementation of the slice for the `__setitem__()` for the `Atoms` class
- Fixing a bug with the assignment of atoms and updating the `species` and `indices` that was broken by the example in the issue above