### PR TITLE
resolve links in project path

### DIFF
--- a/pyiron/base/database/filetable.py
+++ b/pyiron/base/database/filetable.py
@@ -32,7 +32,7 @@ class FileTable(with_metaclass(Singleton)):
     def __init__(self, project):
         self._fileindex = None
         self._job_table = None
-        self._project = os.path.abspath(project)
+        self._project = os.path.realpath(project)
         self._columns = ['id', 'status', 'chemicalformula', 'job', 'subjob', 'projectpath', 'project', 'timestart',
                          'timestop', 'totalcputime', 'computer', 'hamilton', 'hamversion', 'parentid', 'masterid',
                          'username']


### PR DESCRIPTION
pyiron rejects absolute project paths with symlinks in them, even if they point into the pyiron project folder.  Came up for me because of the /u -> /cmmc/u link on the cluster and I was doing some stuff on the command line.