### PR TITLE
Fix Gaussian

### DIFF
--- a/pyiron/gaussian/gaussian.py
+++ b/pyiron/gaussian/gaussian.py
@@ -9,11 +9,15 @@ import matplotlib.pyplot as pt
 from pyiron.dft.job.generic import GenericDFTJob
 from pyiron.base.generic.parameters import GenericParameters
 from pyiron.atomistics.structure.atoms import Atoms
-from molmod.io.fchk import FCHKFile
-from molmod.units import amu,angstrom,electronvolt,centimeter,kcalmol
-from molmod.constants import lightspeed
-from molmod.periodic import periodic
-import tamkin
+
+try:
+    from molmod.io.fchk import FCHKFile
+    from molmod.units import amu,angstrom,electronvolt,centimeter,kcalmol
+    from molmod.constants import lightspeed
+    from molmod.periodic import periodic
+    import tamkin
+except ImportError:
+    pass
 
 
 __author__ = "Jan Janssen, Sander Borgmans"


### PR DESCRIPTION
Except ImportErrors for packages not in dependencies

I am a bit confused why the tests did not fail but when we do not have the package included the import should fail. 