### PR TITLE
Rewrite line mode for band structure calculations

### DIFF
--- a/.ci_support/azure-unix-test-template.yml
+++ b/.ci_support/azure-unix-test-template.yml
@@ -11,7 +11,7 @@ steps:
     conda update -q conda
   displayName: conda setup
 
-- bash: conda create -n pyiron -q --yes -c conda-forge python=$(python.version) "ase>=3.17" coveralls coverage "defusedxml>=0.5.0" "dill>=0.3.0" "future>=0.17.1" "gitpython>=2.1.11" "h5io>=0.1.1" "h5py>=2.9.0" "matplotlib>=2.2.4" "mendeleev>=0.5.1" "molmod>=1.4.5" "numpy>=1.16.4" "pandas>=0.24.2" "pathlib2>=2.3.4" "phonopy>=2.3.2" "psutil>=5.6.3" "pyfileindex>=0.0.4" "pysqa>=0.0.7" "pytables>=3.5.1" "quickff>=2.2.4" "scipy>=1.2.1" "six>=1.12.0" "spglib>=1.14.1" "sqlalchemy>=1.3.8" "tamkin>=1.2.6" "tqdm>=4.35.0" "yaff>=1.4.2"
+- bash: conda create -n pyiron -q --yes -c conda-forge python=$(python.version) "ase>=3.17" coveralls coverage "defusedxml>=0.5.0" "dill>=0.3.0" "future>=0.17.1" "gitpython>=2.1.11" "h5io>=0.1.1" "h5py>=2.9.0" "matplotlib>=2.2.4" "mendeleev>=0.5.1" "molmod>=1.4.5" "numpy>=1.16.4" "pandas>=0.24.2" "pathlib2>=2.3.4" "phonopy>=2.3.2" "psutil>=5.6.3" "pyfileindex>=0.0.4" "pysqa>=0.0.7" "pytables>=3.5.1" "quickff>=2.2.4" "scipy>=1.2.1" "seekpath>=1.9.4" "six>=1.12.0" "spglib>=1.14.1" "sqlalchemy>=1.3.8" "tamkin>=1.2.6" "tqdm>=4.35.0" "yaff>=1.4.2"
   displayName: pyiron environment
 
 - bash: |

--- a/.ci_support/setup_pyiron.sh
+++ b/.ci_support/setup_pyiron.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-conda install -y -c conda-forge python=${1} ase=3.19 coveralls coverage defusedxml=0.6.0 dill=0.3.1.1 future=0.18.2 gitpython=3.1.0 h5io=0.1.1 h5py=2.10.0 matplotlib=3.2.0 mendeleev=0.5.2 molmod=1.4.5 numpy=1.18.1 pandas=1.0.1 pathlib2=2.3.5 phonopy=2.4.2 psutil=5.7.0 pyfileindex=0.0.4 pysqa=0.0.7 pytables=3.6.1 quickff=2.2.4 scipy=1.4.1 six=1.14.0 spglib=1.14.1 sqlalchemy=1.3.14 tamkin=1.2.6 tqdm=4.43.0 yaff=1.4.2
+conda install -y -c conda-forge python=${1} ase=3.19 coveralls coverage defusedxml=0.6.0 dill=0.3.1.1 future=0.18.2 gitpython=3.1.0 h5io=0.1.1 h5py=2.10.0 matplotlib=3.2.0 mendeleev=0.5.2 molmod=1.4.5 numpy=1.18.1 pandas=1.0.1 pathlib2=2.3.5 phonopy=2.4.2 psutil=5.7.0 pyfileindex=0.0.4 pysqa=0.0.7 pytables=3.6.1 quickff=2.2.4 seekpath=1.9.4 scipy=1.4.1 six=1.14.0 spglib=1.14.1 sqlalchemy=1.3.14 tamkin=1.2.6 tqdm=4.43.0 yaff=1.4.2
 pip install --pre .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
 - "conda config --set always_yes yes --set changeps1 no"
 - "conda install -c anaconda setuptools"
 - "conda update -q conda"
-- "conda install -c conda-forge python=%PYTHON_VERSION% ase=3.19 coveralls coverage defusedxml=0.6.0 dill=0.3.1.1 future=0.18.2 gitpython=3.1.0 h5io=0.1.1 h5py=2.10.0 matplotlib=3.2.0 mendeleev=0.5.2 molmod=1.4.5 numpy=1.18.1 pandas=1.0.1 pathlib2=2.3.5 phonopy=2.4.2 psutil=5.7.0 pyfileindex=0.0.4 pysqa=0.0.7 pytables=3.6.1 quickff=2.2.4 scipy=1.4.1 six=1.14.0 spglib=1.14.1 sqlalchemy=1.3.14 tamkin=1.2.6 tqdm=4.43.0 yaff=1.4.2"
+- "conda install -c conda-forge python=%PYTHON_VERSION% ase=3.19 coveralls coverage defusedxml=0.6.0 dill=0.3.1.1 future=0.18.2 gitpython=3.1.0 h5io=0.1.1 h5py=2.10.0 matplotlib=3.2.0 mendeleev=0.5.2 molmod=1.4.5 numpy=1.18.1 pandas=1.0.1 pathlib2=2.3.5 phonopy=2.4.2 psutil=5.7.0 pyfileindex=0.0.4 pysqa=0.0.7 pytables=3.6.1 quickff=2.2.4 scipy=1.4.1 seekpath=1.9.4 six=1.14.0 spglib=1.14.1 sqlalchemy=1.3.14 tamkin=1.2.6 tqdm=4.43.0 yaff=1.4.2"
 - "conda info -a"
 - "pip install --pre ."
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1196,7 +1196,7 @@ class Atoms(object):
         pbc = self.pbc
         cell = sp_dict["primitive_lattice"]
 
-        struc_new = Atoms(elements=element_list, positions=positions, pbc=pbc, cell=cell)
+        struc_new = Atoms(elements=element_list, scaled_positions=positions, pbc=pbc, cell=cell)
 
         struc_new._set_high_symmetry_points(sp_dict["point_coords"])
         struc_new._set_high_symmetry_path({"standard": sp_dict["path"]})

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1199,7 +1199,7 @@ class Atoms(object):
         struc_new = Atoms(elements=element_list, scaled_positions=positions, pbc=pbc, cell=cell)
 
         struc_new._set_high_symmetry_points(sp_dict["point_coords"])
-        struc_new._set_high_symmetry_path({"standard": sp_dict["path"]})
+        struc_new._set_high_symmetry_path({"full": sp_dict["path"]})
 
         return struc_new
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1181,7 +1181,7 @@ class Atoms(object):
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: new structure
         """
-        input_structure = (self.cell, self.get_scaled_positions(), self.indices)
+        input_structure = (np.transpose(self.cell), self.get_scaled_positions(), self.indices)
         sp_dict = seekpath.get_path(structure=input_structure,
                                     with_time_reversal=with_time_reversal,
                                     recipe=recipe,
@@ -1194,7 +1194,7 @@ class Atoms(object):
         element_list = [original_element_list[l] for l in sp_dict["primitive_types"]]
         positions = sp_dict["primitive_positions"]
         pbc = self.pbc
-        cell = sp_dict["primitive_lattice"]
+        cell = np.transpose(sp_dict["primitive_lattice"])
 
         struc_new = Atoms(elements=element_list, scaled_positions=positions, pbc=pbc, cell=cell)
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1172,8 +1172,6 @@ class Atoms(object):
                                    angle_tolerance=-1.0,
                                    ):
         """
-        Creates a new structure!
-
         Uses 'seekpath' to create a new structure with high symmetry points and path for band structure calculations.
 
         Args:

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -338,7 +338,7 @@ class Atoms(object):
             new_points (dict): Points to add
         """
         if self.get_high_symmetry_points() is None:
-            raise AssertionError("Construct high symmetry points first. Use self.band_structure_calculations().")
+            raise AssertionError("Construct high symmetry points first. Use self.create_line_mode_structure().")
         else:
             self._high_symmetry_points.update(new_points)
 
@@ -371,9 +371,19 @@ class Atoms(object):
                 E.G. {"my_path": [('Gamma', 'X'), ('X', 'Y')]}
         """
         if self.get_high_symmetry_path() is None:
-            raise AssertionError("Construct high symmetry path first. Use self.band_structure_calculations().")
-        else:
-            self._high_symmetry_path.update(path)
+            raise AssertionError("Construct high symmetry path first. Use self.create_line_mode_structure().")
+
+        for values_all in path.values():
+            for values in values_all:
+                if not len(values) == 2:
+                    raise ValueError(
+                        "'{}' is not a propper trace! It has to contain exactly 2 values! (start and end point)".format(
+                            values))
+                for v in values:
+                    if v not in self.get_high_symmetry_points().keys():
+                        raise ValueError("'{}' is not a valid high symmetry point".format(v))
+
+        self._high_symmetry_path.update(path)
 
     def new_array(self, name, a, dtype=None, shape=None):
         """
@@ -1154,7 +1164,7 @@ class Atoms(object):
             )
         return self
 
-    def band_structure_calculation(self,
+    def create_line_mode_structure(self,
                                    with_time_reversal=True,
                                    recipe='hpkot',
                                    threshold=1e-07,

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1189,7 +1189,7 @@ class Atoms(object):
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: new structure
         """
-        input_structure = (np.transpose(self.cell), self.get_scaled_positions(), self.indices)
+        input_structure = (self.cell, self.get_scaled_positions(), self.indices)
         sp_dict = seekpath.get_path(structure=input_structure,
                                     with_time_reversal=with_time_reversal,
                                     recipe=recipe,
@@ -1202,7 +1202,7 @@ class Atoms(object):
         element_list = [original_element_list[l] for l in sp_dict["primitive_types"]]
         positions = sp_dict["primitive_positions"]
         pbc = self.pbc
-        cell = np.transpose(sp_dict["primitive_lattice"])
+        cell = sp_dict["primitive_lattice"]
 
         struc_new = Atoms(elements=element_list, scaled_positions=positions, pbc=pbc, cell=cell)
 

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -152,8 +152,8 @@ class GenericDFTJob(AtomisticGenericJob):
         manual_kpoints=None,
         weights=None,
         reciprocal=True,
-        n_trace=None,
-        trace=None,
+        n_path=None,
+        path_name=None,
     ):
         raise NotImplementedError(
             "The set_kpoints function is not implemented for this code."
@@ -169,8 +169,8 @@ class GenericDFTJob(AtomisticGenericJob):
         weights=None,
         reciprocal=True,
         kpoints_per_angstrom=None,
-        n_trace=None,
-        trace=None,
+        n_path=None,
+        path_name=None,
     ):
         """
         Function to setup the k-points
@@ -185,8 +185,8 @@ class GenericDFTJob(AtomisticGenericJob):
             reciprocal (bool): Tells if the supplied values are in reciprocal (direct) or cartesian coordinates (in
             reciprocal space)
             kpoints_per_angstrom (float): Number of kpoint per angstrom in each direction
-            n_trace (int): Number of points per trace part for line mode
-            trace (list): ordered list of high symmetry points for line mode
+            n_path (int): Number of points per trace part for line mode
+            path_name (str): Name of high symmetry path used for band structure calculations.
         """
         if kpoints_per_angstrom is not None:
             if mesh is not None:
@@ -206,8 +206,8 @@ class GenericDFTJob(AtomisticGenericJob):
             manual_kpoints=manual_kpoints,
             weights=weights,
             reciprocal=reciprocal,
-            n_trace=n_trace,
-            trace=trace,
+            n_path=n_path,
+            path_name=path_name,
         )
 
     def calc_static(

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -681,7 +681,10 @@ class SphinxBase(GenericDFTJob):
             else:
                 self._generic_input["path_name"] = path_name
 
-            path = self.structure.get_high_symmetry_path()[path_name]
+            try:
+                path = self.structure.get_high_symmetry_path()[path_name]
+            except KeyError:
+                raise AssertionError("'{}' is not a valid path!".format(path_name))
 
             kpoints = odict([("relative", None)])
 

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -182,6 +182,12 @@ class SphinxBase(GenericDFTJob):
                 [("type", self.input["preconditioner"])]
             )
         control_str[algorithm] = odict()
+        if self.input["maxStepsCCG"] is not None:
+            control_str[algorithm]["maxStepsCCG"] = self.input["maxStepsCCG"]
+        if self.input["blockSize"] is not None and algorithm == "blockCCG":
+            control_str[algorithm]["blockSize"] = self.input["blockSize"]
+        if self.input["nSloppy"] is not None and algorithm == "blockCCG":
+            control_str[algorithm]["nSloppy"] = self.input["nSloppy"]
         if self.input["WriteWaves"] is False:
             control_str["noWavesStorage"] = None
         return control_str

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -688,14 +688,14 @@ class SphinxBase(GenericDFTJob):
             kpoints["from"] = odict(
                 [
                     ("coords", str(self.structure.get_high_symmetry_points()[path[0][0]])),
-                    ("label", '"' + path[0][0] + '"'),
+                    ("label", '"' + path[0][0].replace("'", "p") + '"'),
                 ]
             )
             kpoints["to___0"] = odict(
                 [
                     ("coords", str(self.structure.get_high_symmetry_points()[path[0][1]])),
                     ("nPoints", n_path),
-                    ("label", '"' + path[0][1] + '"'),
+                    ("label", '"' + path[0][1].replace("'", "p") + '"'),
                 ]
             )
 
@@ -706,7 +706,7 @@ class SphinxBase(GenericDFTJob):
                         [
                             ("coords", str(self.structure.get_high_symmetry_points()[path[1][0]])),
                             ("nPoints", 0),
-                            ("label", '"' + path[1][0] + '"'),
+                            ("label", '"' + path[1][0].replace("'", "p") + '"'),
                         ]
                     )
 
@@ -715,7 +715,7 @@ class SphinxBase(GenericDFTJob):
                     [
                         ("coords", str(self.structure.get_high_symmetry_points()[path[1][1]])),
                         ("nPoints", n_path),
-                        ("label", '"' + path[1][1] + '"'),
+                        ("label", '"' + path[1][1].replace("'", "p") + '"'),
                     ]
                 )
 

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -72,8 +72,8 @@ class SphinxBase(GenericDFTJob):
 
         self._kpoints_odict = None
         self._generic_input["restart_for_band_structure"] = False
-        self._generic_input["kpath_name"] = None
-        self._generic_input["n_kpath"] = None
+        self._generic_input["path_name"] = None
+        self._generic_input["n_path"] = None
 
     @property
     def id_pyi_to_spx(self):

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -2312,13 +2312,8 @@ Monkhorst_Pack
             group_name=group_name
         )
         if self._path_name is not None:
-            if "vasp_dict" in hdf.list_nodes():
-                vasp_dict = hdf["vasp_dict"]
-                vasp_dict.update({"path_name": self._path_name})
-                hdf["vasp_dict"] = vasp_dict
-            else:
-                vasp_dict = {"path_name": self._path_name}
-                hdf["vasp_dict"] = vasp_dict
+            with hdf.open("kpoints") as hdf_kpoints:
+                hdf_kpoints["path_name"] = self._path_name
 
     def from_hdf(self, hdf, group_name=None):
         """
@@ -2333,10 +2328,9 @@ Monkhorst_Pack
             group_name=group_name
         )
         self._path_name = None
-        if "vasp_dict" in hdf.list_nodes():
-            vasp_dict = hdf["vasp_dict"]
-            if "path_name" in vasp_dict.keys():
-                self._path_name = vasp_dict["path_name"]
+        with hdf.open("kpoints") as hdf_kpoints:
+            if "path_name" is hdf_kpoints.list_nodes():
+                self._path_name = hdf_kpoints["path_name"]
 
 
 def get_k_mesh_by_cell(cell, kspace_per_in_ang=0.10):

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1102,15 +1102,16 @@ class VaspBase(GenericDFTJob):
             high_symmetry_points = self.structure.get_high_symmetry_points()
             if high_symmetry_points is None:
                 raise ValueError("high_symmetry_points has to be defined")
-            if path_name is None:
+            if path_name is None and self.input.kpoints._path_name is None:
                 raise ValueError("path_name has to be defined")
             if path_name not in self.structure.get_high_symmetry_path().keys():
                 raise ValueError("path_name is not a valid key of high_symmetry_path")
-            self.input.kpoints._set_path_name(path_name)
+            if path_name is not None:
+                self.input.kpoints._set_path_name(path_name)
             self.input.kpoints.set(
                 method="Line",
                 n_path=n_path,
-                path=self._get_path_for_kpoints(path_name)
+                path=self._get_path_for_kpoints(self.input.kpoints._path_name)
             )
         if scheme == "Manual":
             if manual_kpoints is None:

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -59,7 +59,7 @@ class VaspBase(GenericDFTJob):
         >>> ham = VaspBase(job_name="trial_job")
         >>> ham.input.incar[IBRION] = -1
         >>> ham.input.incar[ISMEAR] = 0
-        >>> ham.input.kpoints.set(size_of_mesh=[6, 6, 6])
+        >>> ham.input.kpoints.set_kpoints_file(size_of_mesh=[6, 6, 6])
 
         However, the according to pyiron's philosophy, it is recommended to avoid using code specific tags like IBRION,
         ISMEAR etc. Therefore the recommended way to set this calculation is as follows:
@@ -1089,13 +1089,13 @@ class VaspBase(GenericDFTJob):
         if scheme == "MP":
             if mesh is None:
                 mesh = [int(val) for val in self.input.kpoints[3].split()]
-            self.input.kpoints.set(size_of_mesh=mesh, shift=center_shift)
+            self.input.kpoints.set_kpoints_file(size_of_mesh=mesh, shift=center_shift)
         if scheme == "GC":
             if mesh is None:
                 mesh = [int(val) for val in self.input.kpoints[3].split()]
-            self.input.kpoints.set(size_of_mesh=mesh, shift=center_shift, method="Gamma centered")
+            self.input.kpoints.set_kpoints_file(size_of_mesh=mesh, shift=center_shift, method="Gamma centered")
         if scheme == "GP":
-            self.input.kpoints.set(size_of_mesh=[1, 1, 1], method="Gamma Point")
+            self.input.kpoints.set_kpoints_file(size_of_mesh=[1, 1, 1], method="Gamma Point")
         if scheme == "Line":
             if n_path is None and self.input.kpoints._n_path is None:
                 raise ValueError("n_path has to be defined")
@@ -1113,7 +1113,7 @@ class VaspBase(GenericDFTJob):
             if n_path is not None:
                 self.input.kpoints._n_path = n_path
 
-            self.input.kpoints.set(
+            self.input.kpoints.set_kpoints_file(
                 method="Line",
                 n_path=self.input.kpoints._n_path,
                 path=self._get_path_for_kpoints(self.input.kpoints._path_name)
@@ -2233,7 +2233,7 @@ class Kpoints(GenericParameters):
         self._path_name = None
         self._n_path = None
 
-    def set(self, method=None, size_of_mesh=None, shift=None, n_path=None, path=None):
+    def set_kpoints_file(self, method=None, size_of_mesh=None, shift=None, n_path=None, path=None):
         """
         Sets appropriate tags and values in the KPOINTS file
         Args:
@@ -2286,7 +2286,7 @@ Monkhorst_Pack
                     structure.get_cell(),
                     kspace_per_in_ang=self._dataset["density_of_mesh"],
                 )
-                self.set(size_of_mesh=k_mesh)
+                self.set_kpoints_file(size_of_mesh=k_mesh)
 
     def to_hdf(self, hdf, group_name=None):
         """

--- a/pyiron/vasp/vasp.py
+++ b/pyiron/vasp/vasp.py
@@ -34,7 +34,7 @@ class Vasp(VaspInteractive):
         >>> ham = Vasp(job_name="trial_job")
         >>> ham.input.incar[IBRION] = -1
         >>> ham.input.incar[ISMEAR] = 0
-        >>> ham.input.kpoints.set(size_of_mesh=[6, 6, 6])
+        >>> ham.input.kpoints.set_kpoints_file(size_of_mesh=[6, 6, 6])
 
         However, the according to pyiron's philosophy, it is recommended to avoid using code specific tags like IBRION,
         ISMEAR etc. Therefore the recommended way to set this calculation is as follows:

--- a/setup.py
+++ b/setup.py
@@ -49,14 +49,14 @@ setup(
         'pysqa>=0.0.7',
         'quickff>=2.2.4',
         'scipy>=1.4.1',
+        'seekpath>=1.9.4',
         'six>=1.14.0',
         'spglib>=1.14.1',
         'sqlalchemy>=1.3.14',
         'tables>=3.6.1',
         'tamkin>=1.2.6',
         'tqdm>=4.43.0',
-        'yaff>=1.4.2',
-        'seekpath>=1.9.4'
+        'yaff>=1.4.2'
     ],
     cmdclass=versioneer.get_cmdclass(),
     )

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup(
         'tables>=3.6.1',
         'tamkin>=1.2.6',
         'tqdm>=4.43.0',
-        'yaff>=1.4.2'
+        'yaff>=1.4.2',
+        'seekpath>=1.9.4'
     ],
     cmdclass=versioneer.get_cmdclass(),
     )

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -34,10 +34,13 @@ class TestSphinx(unittest.TestCase):
             cell=2.6 * np.eye(3),
         )
         cls.sphinx = cls.project.create_job("Sphinx", "job_sphinx")
+        cls.sphinx_bs = cls.project.create_job("Sphinx", "sphinx_test_bs")
         cls.sphinx_2_3 = cls.project.create_job("Sphinx", "sphinx_test_2_3")
         cls.sphinx_2_5 = cls.project.create_job("Sphinx", "sphinx_test_2_5")
         cls.sphinx_aborted = cls.project.create_job("Sphinx", "sphinx_test_aborted")
         cls.sphinx.structure = cls.basis
+        cls.sphinx_bs.structure = cls.project.create_structure("Fe", "bcc", 2.81)
+        cls.sphinx_bs.structure = cls.sphinx_bs.structure.band_structure_calculation()
         cls.sphinx_2_3.structure = Atoms(
             elements=["Fe", "Fe"],
             scaled_positions=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
@@ -247,58 +250,49 @@ class TestSphinx(unittest.TestCase):
         mesh = [2, 3, 4]
         center_shift = [0.1, 0.1, 0.1]
 
-        high_sym_points = {
-            "G": [0, 0, 0],
-            "X": [0.5, 0, 0],
-            "Y": [0, 0.5, 0],
-            "M": [0.5, 0.5, 0]
-        }
-        trace = {"my_path": [("G", "X"), ("X", "Y"), ("M", "G")]}
+        trace = {"my_path": [("GAMMA", "H"), ("H", "N"), ("P", "H")]}
         kpoints_dict = odict([('kPoints',
                                odict([('relative', None),
                                       ('from',
-                                       odict([('coords', '[0, 0, 0]'),
-                                              ('label', '"G"')])),
+                                       odict([('coords', '[0.0, 0.0, 0.0]'),
+                                              ('label', '"GAMMA"')])),
                                       ('to___0',
-                                       odict([('coords', '[0.5, 0, 0]'),
+                                       odict([('coords', '[0.5, -0.5, 0.5]'),
                                               ('nPoints', 20),
-                                              ('label', '"X"')])),
+                                              ('label', '"H"')])),
                                       ('to___1',
-                                       odict([('coords', '[0, 0.5, 0]'),
+                                       odict([('coords', '[0.0, 0.0, 0.5]'),
                                               ('nPoints', 20),
-                                              ('label', '"Y"')])),
+                                              ('label', '"N"')])),
                                       ('to___1___1',
-                                       odict([('coords', '[0.5, 0.5, 0]'),
+                                       odict([('coords', '[0.25, 0.25, 0.25]'),
                                               ('nPoints', 0),
-                                              ('label', '"M"')])),
+                                              ('label', '"P"')])),
                                       ('to___2',
-                                       odict([('coords', '[0, 0, 0]'),
+                                       odict([('coords', '[0.5, -0.5, 0.5]'),
                                               ('nPoints', 20),
-                                              ('label', '"G"')]))]))])
+                                              ('label', '"H"')]))]))])
 
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(symmetry_reduction="pyiron rules!")
+            self.sphinx_bs.set_kpoints(symmetry_reduction="pyiron rules!")
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="no valid scheme")
+            self.sphinx_bs.set_kpoints(scheme="no valid scheme")
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", path_name="my_path")
-        with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", path_name="my_path", n_path=20)
+            self.sphinx_bs.set_kpoints(scheme="Line", path_name="my_path")
 
-        self.sphinx.structure.add_high_symmetry_points(high_sym_points)
-        self.sphinx.structure.add_high_symmetry_path(trace)
+        self.sphinx_bs.structure.add_high_symmetry_path(trace)
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", n_path=20)
+            self.sphinx_bs.set_kpoints(scheme="Line", n_path=20)
         with self.assertRaises(AssertionError):
-            self.sphinx.set_kpoints(scheme="Line", path_name="worng name", n_path=20)
+            self.sphinx_bs.set_kpoints(scheme="Line", path_name="worng name", n_path=20)
 
-        self.sphinx.set_kpoints(scheme="Line", path_name="my_path", n_path=20)
-        self.assertEqual(kpoints_dict, self.sphinx._kpoints_odict)
+        self.sphinx_bs.set_kpoints(scheme="Line", path_name="my_path", n_path=20)
+        self.assertEqual(kpoints_dict, self.sphinx_bs._kpoints_odict)
 
-        self.sphinx.set_kpoints(scheme="MP", mesh=mesh, center_shift=center_shift)
-        self.assertIsNone(self.sphinx._kpoints_odict)
-        self.assertEqual(self.sphinx.input["KpointFolding"], mesh)
-        self.assertEqual(self.sphinx.input["KpointCoords"], center_shift)
+        self.sphinx_bs.set_kpoints(scheme="MP", mesh=mesh, center_shift=center_shift)
+        self.assertIsNone(self.sphinx_bs._kpoints_odict)
+        self.assertEqual(self.sphinx_bs.input["KpointFolding"], mesh)
+        self.assertEqual(self.sphinx_bs.input["KpointCoords"], center_shift)
 
     def test_set_empty_states(self):
         with self.assertRaises(ValueError):

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -286,7 +286,7 @@ class TestSphinx(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.sphinx.set_kpoints(scheme="Line", trace=trace, n_trace=20)
 
-        self.sphinx.structure.set_high_symmetry_points(high_sym_points)
+        self.sphinx.structure._set_high_symmetry_points(high_sym_points)
         with self.assertRaises(ValueError):
             self.sphinx.set_kpoints(scheme="Line", n_trace=20)
         with self.assertRaises(AssertionError):

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -40,7 +40,7 @@ class TestSphinx(unittest.TestCase):
         cls.sphinx_aborted = cls.project.create_job("Sphinx", "sphinx_test_aborted")
         cls.sphinx.structure = cls.basis
         cls.sphinx_bs.structure = cls.project.create_structure("Fe", "bcc", 2.81)
-        cls.sphinx_bs.structure = cls.sphinx_bs.structure.band_structure_calculation()
+        cls.sphinx_bs.structure = cls.sphinx_bs.structure.create_line_mode_structure()
         cls.sphinx_2_3.structure = Atoms(
             elements=["Fe", "Fe"],
             scaled_positions=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -253,46 +253,46 @@ class TestSphinx(unittest.TestCase):
             "Y": [0, 0.5, 0],
             "M": [0.5, 0.5, 0]
         }
-        trace = ["G", "X", "M", "Y"]
-        trace_wrong = ["G", "banana", "X"]
+        trace = {"my_path": [("G", "X"), ("X", "Y"), ("M", "G")]}
         kpoints_dict = odict([('kPoints',
                                odict([('relative', None),
                                       ('from',
                                        odict([('coords', '[0, 0, 0]'),
-                                              ('relative', None),
                                               ('label', '"G"')])),
                                       ('to___0',
                                        odict([('coords', '[0.5, 0, 0]'),
                                               ('nPoints', 20),
-                                              ('relative', None),
                                               ('label', '"X"')])),
                                       ('to___1',
-                                       odict([('coords', '[0.5, 0.5, 0]'),
-                                              ('nPoints', 20),
-                                              ('relative', None),
-                                              ('label', '"M"')])),
-                                      ('to___2',
                                        odict([('coords', '[0, 0.5, 0]'),
                                               ('nPoints', 20),
-                                              ('relative', None),
-                                              ('label', '"Y"')]))]))])
+                                              ('label', '"Y"')])),
+                                      ('to___1___1',
+                                       odict([('coords', '[0.5, 0.5, 0]'),
+                                              ('nPoints', 0),
+                                              ('label', '"M"')])),
+                                      ('to___2',
+                                       odict([('coords', '[0, 0, 0]'),
+                                              ('nPoints', 20),
+                                              ('label', '"G"')]))]))])
 
         with self.assertRaises(ValueError):
             self.sphinx.set_kpoints(symmetry_reduction="pyiron rules!")
         with self.assertRaises(ValueError):
             self.sphinx.set_kpoints(scheme="no valid scheme")
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", trace=trace)
+            self.sphinx.set_kpoints(scheme="Line", path_name="my_path")
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", trace=trace, n_trace=20)
+            self.sphinx.set_kpoints(scheme="Line", path_name="my_path", n_path=20)
 
-        self.sphinx.structure._set_high_symmetry_points(high_sym_points)
+        self.sphinx.structure.add_high_symmetry_points(high_sym_points)
+        self.sphinx.structure.add_high_symmetry_path(trace)
         with self.assertRaises(ValueError):
-            self.sphinx.set_kpoints(scheme="Line", n_trace=20)
+            self.sphinx.set_kpoints(scheme="Line", n_path=20)
         with self.assertRaises(AssertionError):
-            self.sphinx.set_kpoints(scheme="Line", trace=trace_wrong, n_trace=20)
+            self.sphinx.set_kpoints(scheme="Line", path_name="worng name", n_path=20)
 
-        self.sphinx.set_kpoints(scheme="Line", trace=trace, n_trace=20)
+        self.sphinx.set_kpoints(scheme="Line", path_name="my_path", n_path=20)
         self.assertEqual(kpoints_dict, self.sphinx._kpoints_odict)
 
         self.sphinx.set_kpoints(scheme="MP", mesh=mesh, center_shift=center_shift)


### PR DESCRIPTION
Using the tool [seekpath](https://github.com/giovannipizzi/seekpath), high symmetry points and paths are created automatically.

The paths are now stored as list of tuples including start and end points, thus discontinuous paths are possible to calculate. E.g. `[("G", "H"), ("H", "N"), ("G", "P")]`.