### PR TITLE
Spx potential - some more fixes 

### DIFF
--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -73,7 +73,7 @@ class SphinxBase(GenericDFTJob):
         self._output_parser = Output(self)
         self.input_writer = InputWriter()
         if self.check_vasp_potentials():
-            self.input["PotType"] = "VASP"  # use VASP potentials if available
+            self.input["VaspPot"] = True  # use VASP potentials if available
         self._kpoints_odict = None
         self._generic_input["restart_for_band_structure"] = False
         self._generic_input["path_name"] = None
@@ -1513,7 +1513,7 @@ class Input(GenericParameters):
             "EmptyStates = auto\n"
             "Sigma = 0.2\n"
             "Xcorr = PBE\n"
-            "PotType = JTH\n"
+            "VaspPot = False\n"
             "Estep = 400\n"
             "Ediff = 1.0e-4\n"
             "WriteWaves = True\n"

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -752,14 +752,24 @@ class SphinxBase(GenericDFTJob):
         check_overlap = self.input["CheckOverlap"]
         enable_kjxc = self.input["KJxc"]
         if self._main_str is None:
-            self.input_writer.write_potentials(
-                file_name="potentials.sx",
-                cwd=self.working_directory,
-                species_str=self._species_str,
-                check_overlap=check_overlap,
-                xc=self.input["Xcorr"],
-                potformat=self.input["PotType"]
-            )
+            if self.input["VaspPot"]:
+                self.input_writer.write_potentials(
+                    file_name="potentials.sx",
+                    cwd=self.working_directory,
+                    species_str=self._species_str,
+                    check_overlap=check_overlap,
+                    xc=self.input["Xcorr"],
+                    potformat="VASP"
+                )
+            else:
+                self.input_writer.write_potentials(
+                    file_name="potentials.sx",
+                    cwd=self.working_directory,
+                    species_str=self._species_str,
+                    check_overlap=check_overlap,
+                    xc=self.input["Xcorr"],
+                    potformat="JTH"
+                )
             self.input_writer.write_guess(
                 file_name="guess.sx",
                 cwd=self.working_directory,

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -60,7 +60,7 @@ class TestSphinx(unittest.TestCase):
         cls.current_dir = os.path.abspath(os.getcwd())
         cls.sphinx._create_working_directory()
         cls.sphinx_2_3._create_working_directory()
-        cls.sphinx.input["PotType"] = "JTH"
+        cls.sphinx.input["VaspPot"] = False
         cls.sphinx.write_input()
         cls.sphinx.version = "2.6"
         cls.sphinx_2_3.to_hdf()
@@ -221,7 +221,7 @@ class TestSphinx(unittest.TestCase):
             "EmptyStates=6;\n",
             "Sigma=0.2;\n",
             "Xcorr=PBE;\n",
-            "PotType=JTH;\n",
+            "VaspPot=false;\n",
             "Estep=400;\n",
             "Ediff=0.0001;\n",
             "WriteWaves=true;\n",

--- a/tests/sphinx/test_interactive.py
+++ b/tests/sphinx/test_interactive.py
@@ -32,7 +32,7 @@ class TestSphinx(unittest.TestCase):
         cls.sphinx.structure.set_initial_magnetic_moments(np.ones(2))
         cls.current_dir = os.path.abspath(os.getcwd())
         cls.sphinx._create_working_directory()
-        cls.sphinx.input["PotType"] = "JTH"
+        cls.sphinx.input["VaspPot"] = False
         cls.sphinx.write_input()
         cls.sphinx.version = "2.6"
         cls.sphinx.server.run_mode.interactive = True


### PR DESCRIPTION
When the VASP potentials are available, they are used by default, to switch to the JTH potentials use: `job.input["VaspPot"] = False`
If the VASP potentials are not available, this option is false by default. 