### PR TITLE
Reload atoms from HDF5 file

### DIFF
--- a/pyiron/base/generic/hdfio.py
+++ b/pyiron/base/generic/hdfio.py
@@ -1285,7 +1285,13 @@ class ProjectHDFio(FileHDFio):
         new_obj = self.create_object(obj_type, **qwargs)
         if obj_type != str(type(new_obj)):  # Backwards compatibility
             self["TYPE"] = str(type(new_obj))
-        new_obj.from_hdf()
+        if obj_type != "<class 'pyiron.atomistics.structure.atoms.Atoms'>":
+            new_obj.from_hdf()
+        else:
+            new_obj.from_hdf(
+                hdf=self.open(".."),
+                group_name=self.h5_path.split('/')[-1]
+            )
         return new_obj
 
     def get_job_id(self, job_specifier):

--- a/pyiron/base/job/jobtype.py
+++ b/pyiron/base/job/jobtype.py
@@ -26,6 +26,7 @@ __date__ = "Sep 1, 2017"
 
 
 JOB_CLASS_DICT = {
+    "Atoms": "pyiron.atomistics.structure.atoms",
     "ScriptJob": "pyiron.base.job.script",
     "SerialMasterBase": "pyiron.base.master.serial",
     "FlexibleMaster": "pyiron.base.master.flexible",

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -213,6 +213,10 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(basis), 8)
         self.assertEqual(basis.get_majority_species()["symbol"], "Al")
         self.assertEqual(basis.get_spacegroup()["Number"], 225)
+        basis = hdf_obj["simple_structure"].to_object()
+        self.assertEqual(len(basis), 8)
+        self.assertEqual(basis.get_majority_species()["symbol"], "Al")
+        self.assertEqual(basis.get_spacegroup()["Number"], 225)
 
     def test_create_Fe_bcc(self):
         self.pse = PeriodicTable()

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -11,7 +11,8 @@ from pyiron.atomistics.structure.atom import Atom
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
 from pyiron.atomistics.structure.sparse_list import SparseList
 from pyiron.atomistics.structure.periodic_table import PeriodicTable, ChemicalElement
-from pyiron.base.generic.hdfio import FileHDFio
+from pyiron.base.generic.hdfio import FileHDFio, ProjectHDFio
+from pyiron.base.project.generic import Project
 
 
 class TestAtoms(unittest.TestCase):
@@ -23,6 +24,12 @@ class TestAtoms(unittest.TestCase):
         ):
             os.remove(
                 os.path.join(file_location, "../../static/atomistics/test_hdf")
+            )
+        if os.path.isfile(
+            os.path.join(file_location, "../../static/atomistics/test.h5")
+        ):
+            os.remove(
+                os.path.join(file_location, "../../static/atomistics/test.h5")
             )
 
     @classmethod
@@ -213,6 +220,21 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(basis), 8)
         self.assertEqual(basis.get_majority_species()["symbol"], "Al")
         self.assertEqual(basis.get_spacegroup()["Number"], 225)
+
+    def test_to_object(self):
+        filename = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "../../static/atomistics",
+        )
+        abs_filename = os.path.abspath(filename)
+        hdf_obj = ProjectHDFio(
+            project=Project(abs_filename),
+            file_name="test.h5"
+        )
+        pos, cell = generate_fcc_lattice()
+        basis_store = Atoms(symbols="Al", positions=pos, cell=cell)
+        basis_store.set_repeat([2, 2, 2])
+        basis_store.to_hdf(hdf_obj, "simple_structure")
         basis = hdf_obj["simple_structure"].to_object()
         self.assertEqual(len(basis), 8)
         self.assertEqual(basis.get_majority_species()["symbol"], "Al")


### PR DESCRIPTION
The code is still very much focused on the Atoms object but in general the idea is to allow any object to be reloaded from the HDF5 file, with the `to_object()` function:

```
from pyiron import Project
from pyiron.base.generic.hdfio import ProjectHDFio
pr = Project('test')
structure = pr.create_structure('Fe', 'bcc', 2.78)
hdf5_file = ProjectHDFio(project=pr, file_name='store.h5')
structure.to_hdf(hdf5_file)
hdf5_file['structure'].to_object()
```

Previously this was only possible for pyiron jobs. 