### PR TITLE
fix exception on accessing missing attribute on JobStatus

### DIFF
--- a/pyiron/base/job/jobstatus.py
+++ b/pyiron/base/job/jobstatus.py
@@ -243,8 +243,8 @@ class JobStatus(object):
         if name in self._status_dict.keys():
             self.refresh_status()
             return self._status_dict[name]
-        else:
-            super(JobStatus, self).__getattr__(name)
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+                                self.__class__.__name__, name))
 
     def __setattr__(self, name, value):
         if name in self._status_dict.keys():


### PR DESCRIPTION
When (accidentally) trying to access a job status check that is not actually defined, like `job.status.queued` instead of `job.status.submitted` you'd get a weird error message like this
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-50-ac32335f0f7e> in <module>
----> 1 jre.status.foo

~/software/pyiron/pyiron/base/job/jobstatus.py in __getattr__(self, name)
    243             return self._status_dict[name]
    244         else:
--> 245             super(JobStatus, self).__getattr__(name)
    246 
    247     def __setattr__(self, name, value):

AttributeError: 'super' object has no attribute '__getattr__'
```
which doesn't explain the actual issue (that you typed the wrong name).

The previous implementation of `__getattr__` tried to escalate to
`object.__getattr__` if the requested attribute name is not one of the
status names, probably to keep normal attribute lookup working.  But
this is not needed because python first calls `__getattribute__` to do the
normal lookup and only then calls `__getattr__` if it is defined[1] and
since object doesn't define `__getattr__` this gave a weird exception when
you tried to access JobStatus.status_name and got the status name wrong.

This now raises the proper AttributeError, while keeping normal
attribute access intact.

Not a big problem, but I stumbled on this this morning, because I mixed up the status names.

[1]: https://docs.python.org/3/reference/datamodel.html?highlight=__getattribute__#object.__getattribute__