### PR TITLE
new create_hkl_surface function

### DIFF
--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -114,11 +114,11 @@ def create_surface(
 
 def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False):
     """
-    Create a surface with an arbitrary surface normal (hkl).
+    Use ase.build.surface to build a surface with surface normal (hkl).
 
     Args:
-        lattice: Atoms bulk instance or str, e.g. "Fe", from
-            which to build the surface
+        lattice (pyiron.atomistics.structure.atoms.Atoms/str): bulk Atoms
+            instance or str, e.g. "Fe", from which to build the surface
         hkl (list): miller indices of surface to be created
         layers (int): # of atomic layers in the surface
         vacuum (float): vacuum spacing
@@ -128,6 +128,8 @@ def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False):
     Returns:
         pyiron.atomistics.structure.atoms.Atoms instance: Required surface
     """
+    # https://gitlab.com/ase/ase/blob/master/ase/lattice/surface.py
+    s.publication_add(publication_ase())
 
     surface = ase_surf(lattice, hkl, layers)
     z_max = np.max(surface.positions[:, 2])
@@ -135,6 +137,7 @@ def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False):
     if center:
         surface.positions += 0.5 * surface.cell[2] - [0, 0, z_max/2]
     return surface
+
 
 def create_structure(element, bravais_basis, lattice_constant):
     """

--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -114,7 +114,7 @@ def create_surface(
 
 def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False):
     """
-    Create a surface with an arbitrary surface normal (hkl). 
+    Create a surface with an arbitrary surface normal (hkl).
 
     Args:
         lattice: Atoms bulk instance or str, e.g. "Fe", from

--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -112,6 +112,30 @@ def create_surface(
         return None
 
 
+def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False):
+    """
+    Create a surface with an arbitrary surface normal (hkl). 
+
+    Args:
+        lattice: Atoms bulk instance or str, e.g. "Fe", from
+            which to build the surface
+        hkl (list): miller indices of surface to be created
+        layers (int): # of atomic layers in the surface
+        vacuum (float): vacuum spacing
+        center (bool): shift all positions to center the surface
+            in the cell
+
+    Returns:
+        pyiron.atomistics.structure.atoms.Atoms instance: Required surface
+    """
+
+    surface = ase_surf(lattice, hkl, layers)
+    z_max = np.max(surface.positions[:, 2])
+    surface.cell[2, 2] = z_max + vacuum
+    if center:
+        surface.positions += 0.5 * surface.cell[2] - [0, 0, z_max/2]
+    return surface
+
 def create_structure(element, bravais_basis, lattice_constant):
     """
     Create a crystal structure using pyiron's native crystal structure generator

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from pyiron.atomistics.structure.atom import Atom
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
-from pyiron.atomistics.structure.generator import create_ase_bulk, create_surface
+from pyiron.atomistics.structure.generator import create_ase_bulk, create_surface, create_hkl_surface
 from pyiron.atomistics.structure.sparse_list import SparseList
 from pyiron.atomistics.structure.periodic_table import PeriodicTable, ChemicalElement
 from pyiron.base.generic.hdfio import FileHDFio, ProjectHDFio
@@ -1336,10 +1336,13 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(struct.get_chemical_formula(), 'Mg4')
 
     def test_static_functions(self):
-        self.assertIsInstance(create_ase_bulk("Al"), Atoms)
+        Al_bulk = create_ase_bulk("Al")
+        self.assertIsInstance(Al_bulk, Atoms)
         surface = create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
         self.assertTrue(all(surface.pbc))
         self.assertIsInstance(surface, Atoms)
+        hkl_surface = create_hkl_surface(Al_bulk, [10,8,7], layers=20, vacuum=10)
+        self.assertIsInstance(hkl_surface, Atoms)
 
     def test_non_periodic(self):
         structure = CrystalStructure("Fe", bravais_basis="bcc", lattice_constant=4.2)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1343,6 +1343,11 @@ class TestAtoms(unittest.TestCase):
         self.assertIsInstance(surface, Atoms)
         hkl_surface = create_hkl_surface(Al_bulk, [10,8,7], layers=20, vacuum=10)
         self.assertIsInstance(hkl_surface, Atoms)
+        hkl_surface_center = create_hkl_surface(
+            Al_bulk, [10,8,7], layers=20, vacuum=10, center=True
+        )
+        mean_z = np.mean([p[2] for p in hkl_surface_center.positions])
+        self.assertAlmostEqual(mean_z, hkl_surface_center.cell[2][2]/2)
 
     def test_non_periodic(self):
         structure = CrystalStructure("Fe", bravais_basis="bcc", lattice_constant=4.2)


### PR DESCRIPTION
I like how easy it is to build simple surfaces using a string like "fcc111", but as far as I can tell, there is no way to use `pyiron.atomistics.structure.generator.create_surface` to make a slab whose miller indices aren't hard-coded into pyiron. I noticed that `create_surface` accepts "ase_surf" as a surface type, but that doesn't seem to work since ase_surf takes fundamentally different args than e.g. fcc111.

The new function `create_hkl_surface` basically wraps ase.build.surface, so it can handle a more flexible set of args, including arbitrary miller indices.

```python
from pyiron.atomistics.structure.generator import create_hkl_surface, create_structure

# based on an element's implicit unit cell
s1 = create_hkl_surface("Al", [10, 8, 7], layers=20, vacuum=10)

# based on an explicit unit cell
Mo_bulk = create_structure("Mo", "bcc", 3.0)
s2 = create_hkl_surface(Mo_bulk, [10, 8, 1], layers=40, vacuum=10, center=True)
```

I'm not sure if this also needs to be accessible by Project. Right now it's not, just to make the diff as small as possible.