### PR TITLE
Making sure vasp runs only 1 ionic step for a static calculation

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -941,6 +941,8 @@ class VaspBase(GenericDFTJob):
         )
         self.input.incar["IBRION"] = -1
         self.input.incar["NELM"] = electronic_steps
+        # Make sure vasp runs only 1 ionic step
+        self.input.incar["NSW"] = 0
         if algorithm is not None:
             if algorithm is not None:
                 self.set_algorithm(algorithm=algorithm)


### PR DESCRIPTION
Ensuring vasp runs only 1 ionic step for static calculations