### PR TITLE
Update spin tag in structure

### DIFF
--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -116,15 +116,15 @@ class GenericDFTJob(AtomisticGenericJob):
 
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: The required structure
-
-
         """
         snapshot = super(GenericDFTJob, self).get_structure(
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
-        spins = self.get("output/generic/dft/atom_spins")
-        if spins is not None:
-            snapshot.set_initial_magnetic_moments(spins[iteration_step])
+        try:
+            if len(self.get_magnetic_moments().shape) > 0:
+                snapshot.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
+        except NotImplementedError:
+            pass
         return snapshot
 
     def set_mixing_parameters(

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -158,6 +158,17 @@ class GenericDFTJob(AtomisticGenericJob):
             "restart_for_band_structure_calculations is not implemented for this code."
         )
 
+    def get_magnetic_moments(self):
+        """
+        Gives the magnetic moments of a calculation
+
+        Returns:
+            numpy.ndarray: array of final magmetic moments
+        """
+        raise NotImplementedError(
+            "'get_magnetic_moments' is not implemented for this code."
+        )
+
     def _set_kpoints(
         self,
         mesh=None,

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -121,8 +121,8 @@ class GenericDFTJob(AtomisticGenericJob):
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
         try:
-            if len(self.get_magnetic_moments().shape) > 0:
-                snapshot.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
+            if len(self.get_magnetic_moments()) > 0:
+                snapshot.set_initial_magnetic_moments(self.get_magnetic_moments(iteration_step=iteration_step))
         except NotImplementedError:
             pass
         return snapshot
@@ -158,9 +158,12 @@ class GenericDFTJob(AtomisticGenericJob):
             "restart_for_band_structure_calculations is not implemented for this code."
         )
 
-    def get_magnetic_moments(self):
+    def get_magnetic_moments(self, iteration_step=-1):
         """
         Gives the magnetic moments of a calculation for each iteration step.
+
+        Args:
+            iteration_step (int): Step for which the structure is requested
 
         Returns:
             numpy.ndarray: array of final magmetic moments

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -160,7 +160,7 @@ class GenericDFTJob(AtomisticGenericJob):
 
     def get_magnetic_moments(self):
         """
-        Gives the magnetic moments of a calculation
+        Gives the magnetic moments of a calculation for each iteration step.
 
         Returns:
             numpy.ndarray: array of final magmetic moments

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -120,11 +120,9 @@ class GenericDFTJob(AtomisticGenericJob):
         snapshot = super(GenericDFTJob, self).get_structure(
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
-        try:
-            if self.get_magnetic_moments() is not None:
-                snapshot.set_initial_magnetic_moments(self.get_magnetic_moments(iteration_step=iteration_step))
-        except NotImplementedError:
-            pass
+        spins = self.get_magnetic_moments(iteration_step=iteration_step)
+        if spins is not None:
+            snapshot.set_initial_magnetic_moments(spins)
         return snapshot
 
     def set_mixing_parameters(
@@ -168,9 +166,11 @@ class GenericDFTJob(AtomisticGenericJob):
         Returns:
             numpy.ndarray/None: array of final magmetic moments or None if no magnetic moment is given
         """
-        raise NotImplementedError(
-            "'get_magnetic_moments' is not implemented for this code."
-        )
+        spins = self.get("output/generic/dft/atom_spins")
+        if spins is not None:
+            return spins[iteration_step]
+        else:
+            return None
 
     def _set_kpoints(
         self,

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -121,7 +121,7 @@ class GenericDFTJob(AtomisticGenericJob):
             iteration_step=iteration_step, wrap_atoms=wrap_atoms
         )
         try:
-            if len(self.get_magnetic_moments()) > 0:
+            if self.get_magnetic_moments() is not None:
                 snapshot.set_initial_magnetic_moments(self.get_magnetic_moments(iteration_step=iteration_step))
         except NotImplementedError:
             pass
@@ -166,7 +166,7 @@ class GenericDFTJob(AtomisticGenericJob):
             iteration_step (int): Step for which the structure is requested
 
         Returns:
-            numpy.ndarray: array of final magmetic moments
+            numpy.ndarray/None: array of final magmetic moments or None if no magnetic moment is given
         """
         raise NotImplementedError(
             "'get_magnetic_moments' is not implemented for this code."

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1341,17 +1341,14 @@ class VaspBase(GenericDFTJob):
         else:
             return self["output/generic/dft/n_elect"]
 
-    def get_magnetic_moments(self, iteration_step=-1):
+    def get_magnetic_moments(self):
         """
-        Gives the magnetic moments of a specific iteration step.
-        Args:
-            iteration_step (int): calculations step to get the magnetic moments for.
+        Gives the magnetic moments of a calculation
 
         Returns:
             numpy.ndarray: array of final magmetic moments
-
         """
-        return self['output/generic/dft/final_magmoms'][iteration_step]
+        return self['output/generic/dft/final_magmoms']
 
     def get_electronic_structure(self):
         """

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1349,9 +1349,12 @@ class VaspBase(GenericDFTJob):
             iteration_step (int): Step for which the structure is requested
 
         Returns:
-            numpy.ndarray: array of final magmetic moments
+            numpy.ndarray/None: array of final magmetic moments or None if no magnetic moment is given
         """
-        return self['output/generic/dft/final_magmoms'][iteration_step]
+        if len(self['output/generic/dft/final_magmoms']) > 0:
+            return self['output/generic/dft/final_magmoms'][iteration_step]
+        else:
+            return None
 
     def get_electronic_structure(self):
         """

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1351,8 +1351,9 @@ class VaspBase(GenericDFTJob):
         Returns:
             numpy.ndarray/None: array of final magmetic moments or None if no magnetic moment is given
         """
-        if len(self['output/generic/dft/final_magmoms']) > 0:
-            return self['output/generic/dft/final_magmoms'][iteration_step]
+        spins = self["output/generic/dft/final_magmoms"]
+        if len(spins) > 0:
+            return spins[iteration_step]
         else:
             return None
 

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1343,7 +1343,7 @@ class VaspBase(GenericDFTJob):
 
     def get_magnetic_moments(self):
         """
-        Gives the magnetic moments of a calculation
+        Gives the magnetic moments of a calculation for each iteration step.
 
         Returns:
             numpy.ndarray: array of final magmetic moments

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1341,6 +1341,18 @@ class VaspBase(GenericDFTJob):
         else:
             return self["output/generic/dft/n_elect"]
 
+    def get_magnetic_moments(self, iteration_step=-1):
+        """
+        Gives the magnetic moments of a specific iteration step.
+        Args:
+            iteration_step (int): calculations step to get the magnetic moments for.
+
+        Returns:
+            numpy.ndarray: array of final magmetic moments
+
+        """
+        return self['output/generic/dft/final_magmoms'][iteration_step]
+
     def get_electronic_structure(self):
         """
         Gets the electronic structure instance from the hdf5 file

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1341,14 +1341,17 @@ class VaspBase(GenericDFTJob):
         else:
             return self["output/generic/dft/n_elect"]
 
-    def get_magnetic_moments(self):
+    def get_magnetic_moments(self, iteration_step=-1):
         """
         Gives the magnetic moments of a calculation for each iteration step.
+
+        Args:
+            iteration_step (int): Step for which the structure is requested
 
         Returns:
             numpy.ndarray: array of final magmetic moments
         """
-        return self['output/generic/dft/final_magmoms']
+        return self['output/generic/dft/final_magmoms'][iteration_step]
 
     def get_electronic_structure(self):
         """

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1352,7 +1352,7 @@ class VaspBase(GenericDFTJob):
             numpy.ndarray/None: array of final magmetic moments or None if no magnetic moment is given
         """
         spins = self["output/generic/dft/final_magmoms"]
-        if len(spins) > 0:
+        if spins is not None and len(spins) > 0:
             return spins[iteration_step]
         else:
             return None

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -57,7 +57,9 @@ class VaspInteractive(VaspBase, GenericInteractive):
         )
 
     def get_structure(self, iteration_step=-1):
-        return GenericInteractive.get_structure(self, iteration_step=iteration_step)
+        structure = GenericInteractive.get_structure(self, iteration_step=iteration_step)
+        structure.set_initial_magnetic_moments(self.get_magnetic_moments(iteration_step=iteration_step))
+        return structure
 
     def interactive_close(self):
         if self.interactive_is_activated():

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -58,7 +58,8 @@ class VaspInteractive(VaspBase, GenericInteractive):
 
     def get_structure(self, iteration_step=-1, wrap_atoms=True):
         structure = GenericInteractive.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
-        structure.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
+        if len(self.get_magnetic_moments()) > 0:
+            structure.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
         return structure
 
     def interactive_close(self):

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -56,9 +56,9 @@ class VaspInteractive(VaspBase, GenericInteractive):
             "interactive_enforce_structure_reset() is not implemented!"
         )
 
-    def get_structure(self, iteration_step=-1):
-        structure = GenericInteractive.get_structure(self, iteration_step=iteration_step)
-        structure.set_initial_magnetic_moments(self.get_magnetic_moments(iteration_step=iteration_step))
+    def get_structure(self, iteration_step=-1, wrap_atoms=True):
+        structure = GenericInteractive.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+        structure.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
         return structure
 
     def interactive_close(self):

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -57,9 +57,24 @@ class VaspInteractive(VaspBase, GenericInteractive):
         )
 
     def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        structure = GenericInteractive.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
-        if len(self.get_magnetic_moments()) > 0:
-            structure.set_initial_magnetic_moments(self.get_magnetic_moments()[iteration_step])
+        """
+        Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
+        there is only one ionic iteration step
+        Args:
+            iteration_step (int): Step for which the structure is requested
+            wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
+
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms: The required structure
+        """
+        if (
+            self.server.run_mode.interactive
+            or self.server.run_mode.interactive_non_modal
+        ):
+            structure = GenericInteractive.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+        else:
+            structure = VaspBase.get_structure(self, iteration_step=iteration_step, wrap_atoms=wrap_atoms)
+
         return structure
 
     def interactive_close(self):


### PR DESCRIPTION
If you use `ham.get_structure(iteration_step)`, the spin tag will be updated. Also a function `get_magnetic_moments()` is created, but for now it is located at `dft/job/generic.py`.