### PR TITLE
Remove warning for default jobs

### DIFF
--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -1399,13 +1399,13 @@ class SphinxBase(GenericDFTJob):
         }
 
         if np.any([len(all_groups[group]) == 0 for group in all_groups]):
-            warnings.warn("The following input groups have not been loaded:\n"
-                + ", ".join([
-                    g for g in all_groups if len(all_groups[g]) == 0
-                    ])
-                + "\n"
-                + "They are set to default values."
-            )
+            # warnings.warn("The following input groups have not been loaded:\n"
+            #     + ", ".join([
+            #         g for g in all_groups if len(all_groups[g]) == 0
+            #         ])
+            #     + "\n"
+            #     + "They are set to default values."
+            # )
             self.load_default_groups()
         if self.structure is None:
             raise AssertionError(


### PR DESCRIPTION
A simple job: 
```
from pyiron import Project
pr = Project('bulk_dft')
job = pr.create_job(pr.job_type.Sphinx, 'job_dft')
job.structure = pr.create_ase_bulk('Al')
job.run()
```
Should not raise a warning, because that might confuse beginners. 