### PR TITLE
update JOB_CLASS_DICT automatically via metaclass

### DIFF
--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -16,6 +16,42 @@ del get_versions
 # jedi fix
 fix_ipython_autocomplete()
 
+# populate namespace with default job classes, this also populates the job
+# class dict in pyiron.base.job.jobtype
+from pyiron.atomistics.structure.atoms import Atoms
+from pyiron.testing.randomatomistic import AtomisticExampleJob
+from pyiron.dft.master.convergence_encut_parallel import ConvEncutParallel
+from pyiron.dft.master.convergence_encut_serial import ConvEncutSerial
+from pyiron.atomistics.master.convergence_volume import ConvergenceVolume
+from pyiron.dft.master.convergence_kpoint_parallel import ConvKpointParallel
+from pyiron.testing.randomatomistic import ExampleJob
+from pyiron.base.master.flexible import FlexibleMaster
+from pyiron.gaussian.gaussian import Gaussian
+from pyiron.gpaw.gpaw import GpawJob
+from pyiron.thermodynamics.hessian import HessianJob
+from pyiron.lammps.lammps import Lammps
+from pyiron.atomistics.master.parallel import MapMaster
+from pyiron.atomistics.master.murnaghan import Murnaghan
+from pyiron.dft.master.murnaghan_dft import MurnaghanDFT
+from pyiron.atomistics.master.phonopy import PhonopyJob
+from pyiron.quickff.quickff import QuickFF
+from pyiron.interactive.scipy_minimizer import ScipyMinimizer
+from pyiron.base.job.script import ScriptJob
+from pyiron.atomistics.master.serial import SerialMaster
+from pyiron.base.master.serial import SerialMasterBase
+from pyiron.sphinx.sphinx import Sphinx
+from pyiron.atomistics.job.structurecontainer import StructureContainer
+from pyiron.atomistics.master.structure import StructureListMaster
+from pyiron.thermodynamics.sxphonons import SxDynMat
+from pyiron.interactive.sxextoptint import SxExtOptInteractive
+from pyiron.thermodynamics.sxphonons import SxHarmPotTst
+from pyiron.thermodynamics.sxphonons import SxPhonons
+from pyiron.thermodynamics.sxphonons import SxUniqDispl
+from pyiron.table.datamining import TableJob
+from pyiron.vasp.vasp import Vasp
+from pyiron.vasp.metadyn import VaspMetadyn
+from pyiron.vasp.vaspsol import VaspSol
+from pyiron.yaff.yaff import Yaff
 
 def install():
     install_dialog()

--- a/pyiron/base/job/core.py
+++ b/pyiron/base/job/core.py
@@ -129,7 +129,7 @@ class JobCore(PyironObject, with_metaclass(RegisterJobTypeMeta)):
     """
 
     if not PRE_PY36:
-        def __init_subclass__(cls, /, **kwargs):
+        def __init_subclass__(cls, **kwargs):
             super().__init_subclass__(**kwargs)
             JOB_CLASS_DICT[cls.__name__] = cls.__module__
 

--- a/pyiron/base/job/jobtype.py
+++ b/pyiron/base/job/jobtype.py
@@ -25,42 +25,7 @@ __status__ = "production"
 __date__ = "Sep 1, 2017"
 
 
-JOB_CLASS_DICT = {
-    "Atoms": "pyiron.atomistics.structure.atoms",
-    "AtomisticExampleJob": "pyiron.testing.randomatomistic",
-    "ConvEncutParallel": "pyiron.dft.master.convergence_encut_parallel",
-    "ConvEncutSerial": "pyiron.dft.master.convergence_encut_serial",
-    "ConvergenceVolume": "pyiron.atomistics.master.convergence_volume",
-    "ConvKpointParallel": "pyiron.dft.master.convergence_kpoint_parallel",
-    "ExampleJob": "pyiron.testing.randomatomistic",
-    "FlexibleMaster": "pyiron.base.master.flexible",
-    "Gaussian": "pyiron.gaussian.gaussian",
-    "GpawJob": "pyiron.gpaw.gpaw",
-    "HessianJob": "pyiron.thermodynamics.hessian",
-    "Lammps": "pyiron.lammps.lammps",
-    "MapMaster": "pyiron.atomistics.master.parallel",
-    "Murnaghan": "pyiron.atomistics.master.murnaghan",
-    "MurnaghanDFT": "pyiron.dft.master.murnaghan_dft",
-    "PhonopyJob": "pyiron.atomistics.master.phonopy",
-    "QuickFF": "pyiron.quickff.quickff",
-    "ScipyMinimizer": "pyiron.interactive.scipy_minimizer",
-    "ScriptJob": "pyiron.base.job.script",
-    "SerialMaster": "pyiron.atomistics.master.serial",
-    "SerialMasterBase": "pyiron.base.master.serial",
-    "Sphinx": "pyiron.sphinx.sphinx",
-    "StructureContainer": "pyiron.atomistics.job.structurecontainer",
-    "StructureListMaster": "pyiron.atomistics.master.structure",
-    "SxDynMat": "pyiron.thermodynamics.sxphonons",
-    "SxExtOptInteractive": "pyiron.interactive.sxextoptint",
-    "SxHarmPotTst": "pyiron.thermodynamics.sxphonons",
-    "SxPhonons": "pyiron.thermodynamics.sxphonons",
-    "SxUniqDispl": "pyiron.thermodynamics.sxphonons",
-    "TableJob": "pyiron.table.datamining",
-    "Vasp": "pyiron.vasp.vasp",
-    "VaspMetadyn": "pyiron.vasp.metadyn",
-    "VaspSol": "pyiron.vasp.vaspsol",
-    "Yaff": "pyiron.yaff.yaff",
-}
+JOB_CLASS_DICT = {}
 
 
 class Singleton(type):


### PR DESCRIPTION
Since we talked about this a while ago and it came up again in #703 (though not as the cause).  I spent some time digging in the [python docs](https://docs.python.org/3.8/reference/datamodel.html#object.__init_subclass__) about subclassing.

With this `JOB_CLASS_DICT` is automatically updated when `JobCore` is subclassed independently from where, so we don't have to manually maintain it and without having to search for subclasses at runtime (as previously).  A downside is that all job types actually need to be imported on importing pyiron (hence the new imports in `pyiron.__init__`) to show up in the auto-completion. But since we want to modularize pyiron in the midterm, it might be ok.   Metaclasses are a bit scary, but hope the comments make it clear how it works.
 
I'm not sure how it interacts with loading custom jobs, but my understanding was that `JOB_CLASS_DICT` exists for the auto-completion only anyways.