### PR TITLE
Fix deletion of named pipes

### DIFF
--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -193,11 +193,12 @@ class SxExtOpt(InteractiveInterface):
         if self.interactive_is_activated():
             self._interactive_library.close()
             self._interactive_library_read.close()
-            self._delete_named_pipes()
+            self._delete_named_pipes(working_directory=self.working_directory)
 
-    def _delete_named_pipes(self):
+    @staticmethod 
+    def _delete_named_pipes(working_directory):
         for file in ["control", "response"]:
-            file_path = posixpath.join(self.working_directory, "control")
+            file_path = posixpath.join(working_directory, file)
             if os.path.exists(file_path):
                 os.remove(file_path)
 
@@ -280,7 +281,7 @@ class SxExtOpt(InteractiveInterface):
         if self.interactive_is_activated():
             self.interactive_close()
         else:
-            self._delete_named_pipes()
+            self._delete_named_pipes(working_directory=self.working_directory)
 
 
 class SxExtOptInteractive(InteractiveWrapper):

--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -196,12 +196,10 @@ class SxExtOpt(InteractiveInterface):
             self._delete_named_pipes()
 
     def _delete_named_pipes(self):
-        control_path = posixpath.join(self.working_directory, "control")
-        if os.path.exists(control_path):
-            os.remove(control_path)
-        response_path = posixpath.join(self.working_directory, "response")
-        if os.path.exists(response_path):
-            os.remove(response_path)
+        for file in ["control", "response"]:
+            file_path = posixpath.join(self.working_directory, "control")
+            if os.path.exists(file_path):
+                os.remove(file_path)
 
     def interactive_is_activated(self):
         if self._interactive_library is None:

--- a/pyiron/interactive/sxextoptint.py
+++ b/pyiron/interactive/sxextoptint.py
@@ -193,8 +193,15 @@ class SxExtOpt(InteractiveInterface):
         if self.interactive_is_activated():
             self._interactive_library.close()
             self._interactive_library_read.close()
-            os.remove(posixpath.join(self.working_directory, "control"))
-            os.remove(posixpath.join(self.working_directory, "response"))
+            self._delete_named_pipes()
+
+    def _delete_named_pipes(self):
+        control_path = posixpath.join(self.working_directory, "control")
+        if os.path.exists(control_path):
+            os.remove(control_path)
+        response_path = posixpath.join(self.working_directory, "response")
+        if os.path.exists(response_path):
+            os.remove(response_path)
 
     def interactive_is_activated(self):
         if self._interactive_library is None:
@@ -274,8 +281,8 @@ class SxExtOpt(InteractiveInterface):
         self.end()
         if self.interactive_is_activated():
             self.interactive_close()
-        os.remove("control")
-        os.remove("response")
+        else:
+            self._delete_named_pipes()
 
 
 class SxExtOptInteractive(InteractiveWrapper):


### PR DESCRIPTION
This should fix the following errors in the automated tests: 

```
Exception ignored in: <function SxExtOpt.__del__ at 0x7f8b47b11440>
2596Traceback (most recent call last):
2597  File "/home/travis/build/pyiron/pyiron/pyiron/interactive/sxextoptint.py", line 276, in __del__
2598    self.interactive_close()
2599  File "/home/travis/build/pyiron/pyiron/pyiron/interactive/sxextoptint.py", line 196, in interactive_close
2600    os.remove(posixpath.join(self.working_directory, "control"))
2601FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/build/pyiron/pyiron/SPX_CHECK_ALL/sxextopt_Al_hdf5/sxextopt_Al/control'
```