### PR TITLE
Fix typo

### DIFF
--- a/notebooks/tests_sphinx_sphinx_check_all.ipynb
+++ b/notebooks/tests_sphinx_sphinx_check_all.ipynb
@@ -353,8 +353,7 @@
     "job.structure.positions[0,0] += 0.01\n",
     "job.server.run_mode.interactive = True\n",
     "job.calc_static()\n",
-    "minim = pr.create_job(pr.job_type.SxExtOptInteractive, 'sxextopt_Al')\n",
-    "minim.ref_job = job\n",
+    "minim = job.create_job(pr.job_type.SxExtOptInteractive, 'sxextopt_Al')\n",
     "minim.run()"
    ]
   },

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1015,7 +1015,7 @@ class GenericJob(JobCore):
             obj_type=[
                 "pyiron.base.master.parallel.ParallelMaster",
                 "pyiron.base.master.serial.SerialMasterBase",
-                "pyiron.atomistic.job.interactivewrapper.InteractiveWrapper",
+                "pyiron.atomistics.job.interactivewrapper.InteractiveWrapper",
             ],
         ):
             job.ref_job = self

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1015,7 +1015,6 @@ class GenericJob(JobCore):
             obj_type=[
                 "pyiron.base.master.parallel.ParallelMaster",
                 "pyiron.base.master.serial.SerialMasterBase",
-                "pyiron.atomistics.job.interactivewrapper.InteractiveWrapper",
             ],
         ):
             job.ref_job = self
@@ -1026,6 +1025,13 @@ class GenericJob(JobCore):
                 or self.server.run_mode.interactive_non_modal
             ):
                 job.server.run_mode.interactive = True
+        elif static_isinstance(
+            obj=job.__class__,
+            obj_type=[
+                "pyiron.atomistics.job.interactivewrapper.InteractiveWrapper",
+            ],
+        ):
+            job.ref_job = self
         return job
 
     def update_master(self):


### PR DESCRIPTION
Example: 
```
from pyiron import Project
pr = Project('interactive')
structure = pr.create_ase_bulk('Al')
structure.positions[0,0] += 0.01
job = pr.create_job(
    job_type=pr.job_type.Sphinx, 
    job_name='spx_interactive')
job.structure = structure 
job.server.run_mode.interactive = True
job.calc_static()
minim = job.create_job(
    job_type=pr.job_type.ScipyMinimizer, 
    job_name='sxextopt_Al')
minim.run()
```