### PR TITLE
don't reset pandas options

### DIFF
--- a/pyiron/base/database/jobtable.py
+++ b/pyiron/base/database/jobtable.py
@@ -214,9 +214,6 @@ def job_table(
     if full_table:
         pandas.set_option('display.max_rows', None)
         pandas.set_option('display.max_columns', None)
-    else:
-        pandas.reset_option('display.max_rows')
-        pandas.reset_option('display.max_columns')
     pandas.set_option("display.max_colwidth", max_colwidth)
     df = pandas.DataFrame(job_dict)
     if len(job_dict) == 0:

--- a/pyiron/base/server/queuestatus.py
+++ b/pyiron/base/server/queuestatus.py
@@ -44,9 +44,6 @@ def queue_table(job_ids=[], project_only=True, full_table=False):
         if full_table:
             pandas.set_option('display.max_rows', None)
             pandas.set_option('display.max_columns', None)
-        else:
-            pandas.reset_option('display.max_rows')
-            pandas.reset_option('display.max_columns')
         df = s.queue_adapter.get_status_of_my_jobs()
         if not project_only:
             return df[


### PR DESCRIPTION
pyiron shouldn't reset pandas options that the user might have set externally as that can be confusing.  I think ideally it also wouldn't set them, but `full_table` is just too useful.  I'm also ok with keeping the current behavior, because I see the convenience, but I just tripped over this and thought somebody else might too.  Anybody has hard opinions on this?