### PR TITLE
maximum forces for the output added

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -836,7 +836,7 @@ class GenericOutput(object):
     @property
     def f_max(self):
         """
-            returns maximum force magnitude of each step which is used for
+            maximum force magnitude of each step which is used for
             convergence criterion of structure optimizations
         """
         return np.linalg.norm(self.forces, axis=-1).max(axis=-1)

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -834,6 +834,14 @@ class GenericOutput(object):
         return self._job["output/generic/forces"]
 
     @property
+    def f_max(self):
+        """
+            returns maximum force magnitude of each step which is used for
+            convergence criterion of structure optimizations
+        """
+        return np.linalg.norm(self.forces, axis=-1).max(axis=-1)
+
+    @property
     def positions(self):
         return self._job["output/generic/positions"]
 

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -834,7 +834,7 @@ class GenericOutput(object):
         return self._job["output/generic/forces"]
 
     @property
-    def f_max(self):
+    def force_max(self):
         """
             maximum force magnitude of each step which is used for
             convergence criterion of structure optimizations


### PR DESCRIPTION
After having had to write `np.linalg.norm(job.output.forces, axis=-1).max(axis=-1)` so many times in order to check force convergence, I finally implemented the output property. User just has to put `job.output.f_max` -> I'm not really sure if this is a good name (although it's essentially equivalent to LAMMPS notation). Let me know what you think.

And maybe we should put in pyiron documentation that force convergence is the maximum force magnitude for structure optimisations (if it's not already written).