### PR TITLE
bugfix for setdefault

### DIFF
--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -466,7 +466,7 @@ class SphinxBase(GenericDFTJob):
             "ekt", self.input["Sigma"]/HARTREE_TO_EV
             )
         self.input.sphinx.PAWHamiltonian.setdefault("xc", self.input["Xcorr"])
-        self.input.sphinx.PAWHamiltonian.setdefault("spinPolarized", self._spin_enabled)
+        self.input.sphinx.PAWHamiltonian["spinPolarized"] = self._spin_enabled
 
     def load_guess_group(self, update_spins=True):
         """

--- a/pyiron/sphinx/base.py
+++ b/pyiron/sphinx/base.py
@@ -743,7 +743,6 @@ class SphinxBase(GenericDFTJob):
         )
 
         new_job.input = self.input
-        new_job.load_default_groups()
 
         if from_charge_density and os.path.isfile(
             posixpath.join(self.working_directory, "rho.sxb")
@@ -764,7 +763,6 @@ class SphinxBase(GenericDFTJob):
                 msg="No wavefunction file (waves.sxb) was found for "
                 + f"job {self.job_name} in {self.working_directory}."
             )
-        new_job.load_default_groups()
         return new_job
 
     def to_hdf(self, hdf=None, group_name=None):


### PR DESCRIPTION
The problem occurred when I was doing something like this:

```
job = pr.create_job('Sphinx', 'spx')
job.structure = pr.create_structure('Fe', 'bcc', 2.83)
job.calc_static()
job.structure.set_initial_magnetic_moments([2,2])
job.calc_static()
```

When the first `job.calc_static()` loads the default input, pyiron thinks it is not a spin-polarised calculation. Then after setting the initial magnetic moments, the changes were not reflected, because SPHInX does `self.input.sphinx.PAWHamiltonian.setdefault('spinPolarized', self._spin_enabled)` internally, which (i.e. `setdefault`) apparently does not overwrite the value.