### PR TITLE
repeat_points added

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1238,6 +1238,18 @@ class Atoms(object):
         self *= vec
 
     def repeat_points(self, points, rep):
+        """
+        Return points with repetition given according to periodic boundary conditions
+
+        Args:
+            points (np.ndarray/list): xyz vector or list/array of xyz vectors
+            rep (int/list/np.ndarray): repetition in each direction.
+                                       If int is given, the same value is used for
+                                       every direction
+
+        Returns:
+            (np.ndarray) repeated points
+        """
         n = np.array([rep]).flatten()
         if len(n)==1:
             n = np.tile(n, 3)

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1237,6 +1237,21 @@ class Atoms(object):
     def set_repeat(self, vec):
         self *= vec
 
+    def repeat_points(self, points, rep):
+        n = np.array([rep]).flatten()
+        if len(n)==1:
+            n = np.tile(n, 3)
+        if len(n)!=3:
+            raise ValueError('rep must be an integer or a list of 3 integers')
+        vector = np.array(points)
+        if vector.shape[-1]!=3:
+            raise ValueError('points must be an xyz vector or a list/array of xyz vectors')
+        v = vector.reshape(-1, 3)
+        meshgrid = np.meshgrid(np.arange(n[0]), np.arange(n[1]), np.arange(n[2]))
+        v_repeated = np.einsum('ni,ij->nj', np.stack(meshgrid, axis=-1).reshape(-1, 3), self.cell)
+        v_repeated = v_repeated[:, np.newaxis, :]+v[np.newaxis, :, :]
+        return v_repeated.reshape((-1,)+vector.shape)
+
     def reset_absolute(self, is_absolute):
         raise NotImplementedError("This function was removed!")
 

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -810,6 +810,20 @@ class TestAtoms(unittest.TestCase):
         self.assertTrue(np.allclose(basis.get_distances(a0=0.5*np.ones(3)), basis.get_distances(a1=0.5*np.ones(3))))
         self.assertTrue(np.allclose(basis.get_distances(vector=True)[0,1], -0.1*np.ones(3)))
 
+    def test_repeat_points(self):
+        basis = Atoms("Fe", positions=np.random.rand(3).reshape(-1, 3), cell=np.identity(3))
+        basis.cell[0, 1] = 0.01
+        with self.assertRaises(ValueError):
+            basis.repeat_points([0, 0, 0], [2 ,2])
+        with self.assertRaises(ValueError):
+            basis.repeat_points([0, 0], 2)
+        v = np.random.rand(3)
+        w = basis.repeat_points(v, 3)
+        v += np.array([1, 0.01, 0])
+        self.assertAlmostEqual(np.linalg.norm(w-v, axis=-1).min(), 0)
+        v = np.random.rand(6).reshape(-1, 3)
+        self.assertEqual(basis.repeat_points(v, 2).shape, (8, 2, 3))
+
     def test_cluster_analysis(self):
         import random
 


### PR DESCRIPTION
Points are repeated in the same way as `repeat`, e.g.:

```
structure.repeat_points(points=[0.1, 0.2, 0.3], rep=[3, 3, 3])
```

The return value is the set of points repeated in each direction.

Tests and DocString will be added shortly.