### PR TITLE
Update sphinx version in unittests

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -185,20 +185,30 @@ class AtomisticGenericJob(GenericJobCore):
         return new_generic_job
 
     def calc_minimize(
-        self, e_tol=0, f_tol=1e-4, max_iter=1000, pressure=None, n_print=1
+        self, ionic_energy=0, ionic_forces=1e-4, e_tol=None, f_tol=None, max_iter=1000, pressure=None, n_print=1
     ):
         """
 
         Args:
-            e_tol:
-            f_tol:
-            max_iter:
-            pressure:
-            n_print:
+            e_tol (float): Maximum energy difference between 2 steps
+            f_tol (float): Maximum force magnitude that each of atoms is allowed to have
+            max_iter (int): Maximum number of force evluations
+            pressure (float/list): Targetpressure values
+            n_print (int): Print period
 
         Returns:
 
         """
+        if e_tol is not None:
+            warnings.warn(
+                "e_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
+            ionic_energy = e_tol
+            e_tol = None
+        if f_tol is not None:
+            warnings.warn(
+                "f_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
         self._generic_input["calc_mode"] = "minimize"
         self._generic_input["max_iter"] = max_iter
         self._generic_input["pressure"] = pressure

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -573,8 +573,10 @@ class LammpsBase(AtomisticGenericJob):
 
     def calc_minimize(
             self,
-            e_tol=0.0,
-            f_tol=1e-4,
+            ionic_energy=0.0,
+            ionic_forces=1e-4,
+            e_tol=None,
+            f_tol=None,
             max_iter=1000000,
             pressure=None,
             n_print=100,
@@ -582,16 +584,28 @@ class LammpsBase(AtomisticGenericJob):
     ):
         rotation_matrix = self._get_rotation_matrix(pressure=pressure)
         # Docstring set programmatically -- Ensure that changes to signature or defaults stay consistent!
+        if e_tol is not None:
+            warnings.warn(
+                "e_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
+            ionic_energy = e_tol
+            e_tol = None
+        if f_tol is not None:
+            warnings.warn(
+                "f_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
+            ionic_forces = f_tol
+            f_tol = None
         super(LammpsBase, self).calc_minimize(
-            e_tol=e_tol,
-            f_tol=f_tol,
+            ionic_energy=ionic_energy,
+            ionic_forces=ionic_forces,
             max_iter=max_iter,
             pressure=pressure,
             n_print=n_print,
         )
         self.input.control.calc_minimize(
-            e_tol=e_tol,
-            f_tol=f_tol,
+            ionic_energy=ionic_energy,
+            ionic_forces=ionic_forces,
             max_iter=max_iter,
             pressure=pressure,
             n_print=n_print,

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -250,8 +250,10 @@ class LammpsControl(GenericParameters):
 
     def calc_minimize(
         self,
-        e_tol=0.0,
-        f_tol=1e-4,
+        ionic_energy=0.0,
+        ionic_forces=1e-4,
+        e_tol=None,
+        f_tol=None,
         max_iter=100000,
         pressure=None,
         n_print=100,
@@ -262,10 +264,12 @@ class LammpsControl(GenericParameters):
         Sets parameters required for minimization.
 
         Args:
-            e_tol (float): If the magnitude of difference between energies of two consecutive steps is lower than or
-                equal to `e_tol`, the minimisation terminates. (Default is 0.0 eV.)
-            f_tol (float): If the magnitude of the global force vector at a step is lower than or equal to `f_tol`, the
+            ionic_energy (float): If the magnitude of difference between energies of two consecutive steps is lower than or
+                equal to `ionic_energy`, the minimisation terminates. (Default is 0.0 eV.)
+            ionic_forces (float): If the magnitude of the global force vector at a step is lower than or equal to `ionic_forces`, the
                 minimisation terminates. (Default is 1e-4 eV/angstrom.)
+            e_tol (float): Same as ionic_energy (Deprecated)
+            f_tol (float): Same as ionic_forces (Deprecated)
             max_iter (int): Maximum number of minimisation steps to carry out. If the minimisation converges before
                 `max_iter` steps, terminate at the converged step. If the minimisation does not converge up to
                 `max_iter` steps, terminate at the `max_iter` step. (Default is 100000.)
@@ -283,6 +287,19 @@ class LammpsControl(GenericParameters):
         # pyiron.lammps.interactive.LammpsInteractive.calc_minimize -- Please ensure that changes to signature or
         # defaults stay consistent!
 
+        if e_tol is not None:
+            warnings.warn(
+                "e_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
+            ionic_energy = e_tol
+            e_tol = None
+        if f_tol is not None:
+            warnings.warn(
+                "f_tol is deprecated as of vers. 0.3.0. It is not guaranteed to be in service in vers. 0.4.0"
+            )
+            ionic_forces = f_tol
+            f_tol = None
+
         max_evaluations = 100 * max_iter
 
         if self["units"] not in LAMMPS_UNIT_CONVERSIONS.keys():
@@ -291,8 +308,8 @@ class LammpsControl(GenericParameters):
         force_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"]
         pressure_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
 
-        e_tol *= energy_units
-        f_tol *= force_units
+        ionic_energy *= energy_units
+        ionic_forces *= force_units
 
         if pressure is not None:
             if None in np.array([pressure]).flatten():
@@ -312,9 +329,9 @@ class LammpsControl(GenericParameters):
         self.remove_keys(["fix___nve"])
         self.set(min_style=style)
         self.set(
-            minimize=str(e_tol)
+            minimize=str(ionic_energy)
             + " "
-            + str(f_tol)
+            + str(ionic_forces)
             + " "
             + str(int(max_iter))
             + " "

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -230,8 +230,10 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
 
     def calc_minimize(
             self,
-            e_tol=0.0,
-            f_tol=1e-4,
+            ionic_energy=0.0,
+            ionic_forces=1e-4,
+            e_tol=None,
+            f_tol=None,
             max_iter=100000,
             pressure=None,
             n_print=100,

--- a/pyiron/lammps/interactive.py
+++ b/pyiron/lammps/interactive.py
@@ -245,6 +245,8 @@ class LammpsInteractive(LammpsBase, GenericInteractive):
                 "calc_minimize() is not implemented for the non modal interactive mode use calc_static()!"
             )
         super(LammpsInteractive, self).calc_minimize(
+            ionic_energy=ionic_energy,
+            ionic_forces=ionic_forces,
             e_tol=e_tol,
             f_tol=f_tol,
             max_iter=max_iter,

--- a/tests/sphinx/test_base.py
+++ b/tests/sphinx/test_base.py
@@ -67,7 +67,6 @@ class TestSphinx(unittest.TestCase):
         cls.sphinx.load_default_groups()
         cls.sphinx.fix_symmetry = False
         cls.sphinx.write_input()
-        cls.sphinx.version = "2.6.1"
         cls.sphinx_2_3.to_hdf()
         cls.sphinx_2_3.decompress()
         cls.sphinx_2_5.decompress()


### PR DESCRIPTION
`sphinx` in unit test is supposed to be used for the latest version of SPHInX (in contrast to other ones like `sphinx_2_3` or `sphinx_2_5`)