### PR TITLE
check if potential supports correct elements

### DIFF
--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -158,17 +158,17 @@ class LammpsBase(AtomisticGenericJob):
             potential = potential_db.find_by_name(potential_filename)
         elif isinstance(potential_filename, pd.DataFrame):
             potential = potential_filename
-            if self.structure:
-                structure_elements = self.structure.get_species_symbols()
-                potential_elements = potential["Species"][0]
-                if not set(structure_elements).issubset(potential_elements):
-                    raise ValueError("Potential {} does not support elements "
-                                     "in structure {}.".format(
-                                         potential_elements,
-                                         structure_elements
-                                    ))
         else:
             raise TypeError("Potentials have to be strings or pandas dataframes.")
+        if self.structure:
+            structure_elements = self.structure.get_species_symbols()
+            potential_elements = list(potential["Species"])[0]
+            if not set(structure_elements).issubset(potential_elements):
+                raise ValueError("Potential {} does not support elements "
+                                 "in structure {}.".format(
+                                     potential_elements,
+                                     structure_elements
+                                ))
         self.input.potential.df = potential
         for val in ["units", "atom_style", "dimension"]:
             v = self.input.potential[val]

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -158,6 +158,15 @@ class LammpsBase(AtomisticGenericJob):
             potential = potential_db.find_by_name(potential_filename)
         elif isinstance(potential_filename, pd.DataFrame):
             potential = potential_filename
+            if self.structure:
+                structure_elements = self.structure.get_species_symbols()
+                potential_elements = potential["Species"][0]
+                if not set(structure_elements).issubset(potential_elements):
+                    raise ValueError("Potential {} does not support elements "
+                                     "in structure {}.".format(
+                                         potential_elements,
+                                         structure_elements
+                                    ))
         else:
             raise TypeError("Potentials have to be strings or pandas dataframes.")
         self.input.potential.df = potential


### PR DESCRIPTION
When setting a custom potential on lammps jobs via pandas dataframe, we used to accept everything.  This checks at least whether the potential advertises the correct species list for the species present in the structure.  I could also add checks for the other members as per [FAQ](https://pyiron.readthedocs.io/en/latest/source/faq.html#how-to-use-a-custom-potential-in-lammps), but I'm not 100% sure what all of them are or what downstream code expects there.