### PR TITLE
Execute interactive master jobs in the background

### DIFF
--- a/pyiron/base/master/parallel.py
+++ b/pyiron/base/master/parallel.py
@@ -683,6 +683,8 @@ class ParallelMaster(GenericMaster):
                 self.server.run_mode.interactive and job.server.run_mode.interactive
             ):
                 self._run_if_master_modal_child_modal(job)
+            elif self.server.run_mode.non_modal and job.server.run_mode.interactive:
+                self.run_if_interactive()
             elif self.server.run_mode.modal and job.server.run_mode.non_modal:
                 self._run_if_master_modal_child_non_modal(job)
             else:


### PR DESCRIPTION
```
from pyiron import Project
pr = Project("murn")
structure = pr.create_ase_bulk("Al", cubic=True)
job = pr.create_job(pr.job_type.Lammps, "lmp")
job.structure = structure
job.potential = 'Al_Mg_Mendelev_eam'
job.server.run_mode.interactive = True
murn = job.create_job(pr.job_type.Murnaghan, "murn")
murn.server.run_mode.non_modal = True
murn.run()
pr.wait_for_job(murn)
```