### PR TITLE
allow abitrary object loading with `to_object()`

### DIFF
--- a/docs/source/hdf5.rst
+++ b/docs/source/hdf5.rst
@@ -1,0 +1,81 @@
+===============================
+HDF5 Serialization Architecture
+===============================
+
+---------
+Structure
+---------
+
+Each hierachical object lives under its own group in the hdf, i.e. objects that
+are attributes of another must have their own sub-group in that larger objects
+group.  In its group each object must store
+    - 'TYPE' equal to `str(type(self))`
+      this provides the module path and class name from which pyiron will load
+      a class
+    - 'NAME' equal to `type(self).__name__`
+      the unqualified class name, informational only
+They may also store
+    - 'HDF_VERSION' equal to a version string with format MAJOR.MINOR.PATCH
+      the version of the structure of the type *in HDF5*; all classes
+      must be able to read from HDF5 with at least the same MAJOR release, but
+      explicit breaking behaviour should be very rare
+    - 'VERSION' equal to a version string with format MAJOR.MINOR.PATCH
+      the version of the functionality of the class; higher version must not
+      change the HDF5 structure unless they also change HDF_VERSION
+
+For example a class defined like this
+.. code-block::
+
+    class Foo:
+        def __init__(self, parameter):
+            self.bar = Bar()
+            self.baz = Baz()
+            self.parameter = parameter
+
+should be serialized as
+.. code-block::
+    foo/
+    foo/TYPE
+    foo/NAME
+    foo/VERSION
+    foo/HDF_VERSION
+    foo/parameter
+    foo/bar/
+    foo/bar/TYPE
+    foo/bar/NAME
+    foo/bar/VERSION
+    foo/bar/HDF_VERSION
+    foo/baz/
+    foo/baz/TYPE
+    foo/baz/NAME
+    foo/baz/VERSION
+    foo/baz/HDF_VERSION
+
+---------------
+Writing to HDF5
+---------------
+
+Each type must define a `to_hdf(self, hdf, group_name = None)` method that
+takes the given `hdf` object, creates a subgroup called `group_name` in it (if
+given) and then serializes itself to this group.  Some objects may keep a
+default `ProjectHDFio` object during their lifetime (e.g. jobs), in this case
+`hdf` maybe an optional parameter.
+
+-----------------
+Reading from HDF5
+-----------------
+
+Each type must define a `from_hdf(self, hdf, group_name = None)` method and may
+define a `from_hdf_args(cls, hdf)`.  `from_hdf()` restores the state of the
+already initialized object from the information stored in the HDF5 file.
+`from_hdf_args()` reads the required parameters to instantiate the object from
+HDF5 and returns them in a `dict`.
+
+To read an object from a given `ProjectHDFio` path, call the `to_object()`
+method.  This will first call `import_class` to read the class object, then
+`make_from_hdf()` to instantiate it, if the class defines `from_hd_args()` it
+will be called to supply the correct init parameters.  `to_object()` can also
+be supplied with additional paraters to overrride the ones written to HDF5, in
+particular it will always provide `job_name` and `project`.  However only those
+parameters that are needed (i.e. declared by that classes' `__init__()`) will
+be passed.

--- a/pyiron/base/generic/hdfio.py
+++ b/pyiron/base/generic/hdfio.py
@@ -1239,7 +1239,7 @@ class ProjectHDFio(FileHDFio):
             class_name (str): fully qualified name of a pyiron class
 
         Returns:
-            class object: class object of the given name
+            type: class object of the given name
         """
         internal_class_name = class_name.split(".")[-1][:-2]
         if internal_class_name in self._project.job_type.job_class_dict:
@@ -1264,6 +1264,9 @@ class ProjectHDFio(FileHDFio):
         Args:
             cls (type): pyiron type to instantiate
             **kwargs: arguments for instance creation
+
+        Returns:
+            cls: instance of the given type
         """
 
         if hasattr(cls, "from_hdf_args"):
@@ -1287,7 +1290,7 @@ class ProjectHDFio(FileHDFio):
                       parameters
 
         Returns:
-            GenericJob: pyiron object
+            pyiron object of the given class_name
         """
         if "TYPE" not in self.list_nodes() and class_name is None:
             raise ValueError(

--- a/pyiron/base/generic/hdfio.py
+++ b/pyiron/base/generic/hdfio.py
@@ -7,7 +7,6 @@ from __future__ import print_function
 import h5py
 import os
 import importlib
-import inspect
 import pandas
 import posixpath
 import h5io

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1196,7 +1196,7 @@ class GenericJob(JobCore):
         if hdf is not None:
             self._hdf5 = hdf
         if group_name is not None:
-            self._hdf5.open(group_name)
+            self._hdf5 = self._hdf5.open(group_name)
         self._type_from_hdf()
         self._server.from_hdf(self._hdf5)
         with self._hdf5.open("input") as hdf_input:

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -18,6 +18,7 @@ from pyiron.base.settings.generic import Settings
 from pyiron.base.job.executable import Executable
 from pyiron.base.job.jobstatus import JobStatus
 from pyiron.base.job.core import JobCore
+from pyiron.base.generic.hdfio import ProjectHDFio
 from pyiron.base.generic.util import static_isinstance
 from pyiron.base.server.generic import Server
 from pyiron.base.database.filetable import FileTable
@@ -1184,6 +1185,21 @@ class GenericJob(JobCore):
                 "exclude_groups_hdf": self._exclude_groups_hdf,
             }
             hdf_input["generic_dict"] = generic_dict
+
+    @classmethod
+    def from_hdf_args(cls, hdf):
+        """
+        Read arguments for instance creation from HDF5 file
+
+        Args:
+            hdf (ProjectHDFio): HDF5 group object
+        """
+        job_name = posixpath.splitext(posixpath.basename(hdf.file_name))[0]
+        project_hdf5 = ProjectHDFio(
+                project = hdf._create_project_from_hdf5(),
+                file_name = job_name
+        )
+        return {"job_name": job_name, "project": project_hdf5}
 
     def from_hdf(self, hdf=None, group_name=None):
         """

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -18,7 +18,6 @@ from pyiron.base.settings.generic import Settings
 from pyiron.base.job.executable import Executable
 from pyiron.base.job.jobstatus import JobStatus
 from pyiron.base.job.core import JobCore
-from pyiron.base.generic.hdfio import ProjectHDFio
 from pyiron.base.generic.util import static_isinstance
 from pyiron.base.server.generic import Server
 from pyiron.base.database.filetable import FileTable

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1195,7 +1195,7 @@ class GenericJob(JobCore):
             hdf (ProjectHDFio): HDF5 group object
         """
         job_name = posixpath.splitext(posixpath.basename(hdf.file_name))[0]
-        project_hdf5 = ProjectHDFio(
+        project_hdf5 = type(hdf)(
                 project = hdf._create_project_from_hdf5(),
                 file_name = job_name
         )

--- a/pyiron/base/master/generic.py
+++ b/pyiron/base/master/generic.py
@@ -454,12 +454,10 @@ class GenericMaster(GenericJob):
         if job_name in self._job_object_dict.keys():
             return self._job_object_dict[job_name]
         else:
-            ham_obj = self.project_hdf5.create_object(
-                class_name=self._hdf5[job_name + "/TYPE"],
-                project=self._hdf5,
-                job_name=job_name,
+            ham_obj = self.project_hdf5[job_name].to_object(
+                    project=self.project_hdf5,
+                    job_name=job_name,
             )
-            ham_obj.from_hdf()
             return ham_obj
 
     def _to_hdf_child_function(self, hdf):


### PR DESCRIPTION
It turns out there's only small changes `to_object()` needed to allow loading any type of object from HDF5. I'll add tests & more docs, but I also wrote up a bit about how writing and reading works [here](https://github.com/pyiron/pyiron/blob/jobcore/docs/source/hdf5.rst) and I'd like your comments for the meeting tomorrow.  Naturally it's not quite complete and I'm not sure the page should mesh with the rest of the docs, but it's a start.