### PR TITLE
require user input in `remove_jobs` + create `remove_jobs_silently`

### DIFF
--- a/notebooks/bandstructure.ipynb
+++ b/notebooks/bandstructure.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.remove_jobs(recursive=True)"
+    "pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/data_mining.ipynb
+++ b/notebooks/data_mining.ipynb
@@ -33,7 +33,7 @@
     "pr = Project(\"potential_scan\")\n",
     "\n",
     "## Uncomment the next line if you want to remove all jobs and start again\n",
-    "# pr.remove_jobs(recursive=True)"
+    "# pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/energy_volume_curve.ipynb
+++ b/notebooks/energy_volume_curve.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "pr = Project(path='thermo')\n",
-    "# pr.remove_jobs(recursive=True)"
+    "# pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/gamma_surface_parallel_master.ipynb
+++ b/notebooks/gamma_surface_parallel_master.ipynb
@@ -212,7 +212,7 @@
    },
    "outputs": [],
    "source": [
-    "pr.remove_jobs(recursive=True)"
+    "pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/lammps-fe-c-example.ipynb
+++ b/notebooks/lammps-fe-c-example.ipynb
@@ -39,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "pr.remove_jobs()"
+    "pr.remove_jobs_silently()"
    ]
   },
   {

--- a/notebooks/phonopy_example.ipynb
+++ b/notebooks/phonopy_example.ipynb
@@ -40,8 +40,8 @@
    "outputs": [],
    "source": [
     "pr = Project(\"PhonopyExample\")\n",
-    "pot =  'Al_Mg_Mendelev_eam'\n",
-    "pr.remove_jobs(recursive=True)"
+    "pot = 'Al_Mg_Mendelev_eam'\n",
+    "pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/sqs.ipynb
+++ b/notebooks/sqs.ipynb
@@ -24,7 +24,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pr.remove_jobs(recursive=True)"
+    "pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/notebooks/test_pyiron_installation.ipynb
+++ b/notebooks/test_pyiron_installation.ipynb
@@ -310,7 +310,7 @@
    "source": [
     "from pyiron import Project\n",
     "pr = Project('lammps')\n",
-    "pr.remove_jobs(recursive=True)\n",
+    "pr.remove_jobs_silently(recursive=True)\n",
     "lmp = pr.create_job(pr.job_type.Lammps, 'static')\n",
     "lmp.structure = pr.create_structure('Fe', 'bcc', 2.55)\n",
     "lmp.potential = 'Fe_C_Hepburn_Ackland_eam'\n",
@@ -343,7 +343,7 @@
    "source": [
     "from pyiron import Project\n",
     "pr = Project('lammps')\n",
-    "pr.remove_jobs(recursive=True)\n",
+    "pr.remove_jobs_silently(recursive=True)\n",
     "lmp = pr.create_job(pr.job_type.Lammps, 'interactive')\n",
     "lmp.structure = pr.create_structure('Fe', 'bcc', 2.55)\n",
     "lmp.potential = 'Fe_C_Hepburn_Ackland_eam'\n",
@@ -403,7 +403,7 @@
    "source": [
     "from pyiron import Project\n",
     "pr = Project('sphinx')\n",
-    "pr.remove_jobs(recursive=True)\n",
+    "pr.remove_jobs_silently(recursive=True)\n",
     "lmp = pr.create_job(pr.job_type.Sphinx, 'static')\n",
     "lmp.structure = pr.create_structure('Fe', 'bcc', 2.55)\n",
     "lmp.run()  # The job static was saved and received the ID: 2"
@@ -456,7 +456,7 @@
    "source": [
     "from pyiron import Project\n",
     "pr = Project('gpaw')\n",
-    "pr.remove_jobs(recursive=True)\n",
+    "pr.remove_jobs_silently(recursive=True)\n",
     "lmp = pr.create_job(pr.job_type.GpawJob, 'static')\n",
     "lmp.structure = pr.create_structure('Fe', 'bcc', 2.55)\n",
     "lmp.run()  # The job static was saved and received the ID: 3"

--- a/notebooks/tests_sphinx_sphinx_check_all.ipynb
+++ b/notebooks/tests_sphinx_sphinx_check_all.ipynb
@@ -27,7 +27,7 @@
    "outputs": [],
    "source": [
     "pr = Project('SPX_CHECK_ALL')\n",
-    "pr.remove_jobs(recursive=True)"
+    "pr.remove_jobs_silently(recursive=True)"
    ]
   },
   {

--- a/pyiron/base/project/generic.py
+++ b/pyiron/base/project/generic.py
@@ -1020,35 +1020,21 @@ class Project(ProjectPath):
         """
         if not isinstance(recursive, bool):
             raise ValueError('recursive must be a boolean')
-        if not self.view_mode:
-            confirmed = None
-            while confirmed not in ["y", "n"]:
-                if confirmed is None:
-                    confirmed = input(
-                        "Are you sure you want to delete all jobs from "
-                        + f"'{self.base_name}'? y/(n)"
-                        ).lower()
-                else:
-                    confirmed = input(
-                        "Invalid response. Please enter 'y' (yes) or 'n' (no): "
-                        ).lower()
-            if confirmed == "y":
-                # proceed to delete the jobs
-                for job_id in self.get_job_ids(recursive=recursive):
-                    if job_id not in self.get_job_ids(recursive=recursive):
-                        continue
-                    else:
-                        try:
-                            self.remove_job(job_specifier=job_id)
-                            s.logger.debug("Remove job with ID {0} ".format(job_id))
-                        except (IndexError, Exception):
-                            s.logger.debug(
-                                "Could not remove job with ID {0} ".format(job_id)
-                            )
+        confirmed = None
+        while confirmed not in ["y", "n"]:
+            if confirmed is None:
+                confirmed = input(
+                    "Are you sure you want to delete all jobs from "
+                    + f"'{self.base_name}'? y/(n)"
+                    ).lower()
             else:
-                print(f"No jobs removed from '{self.base_name}'.")
+                confirmed = input(
+                    "Invalid response. Please enter 'y' (yes) or 'n' (no): "
+                    ).lower()
+        if confirmed == "y":
+            self.remove_jobs_silently(recursive=recursive)
         else:
-            raise EnvironmentError("copy_to: is not available in Viewermode !")
+            print(f"No jobs removed from '{self.base_name}'.")
 
     def remove_jobs_silently(self, recursive=False):
         """

--- a/pyiron/cli/rm.py
+++ b/pyiron/cli/rm.py
@@ -36,7 +36,7 @@ def main(args):
 
     pr = pyiron.Project(args.project)
     if args.jobs_only:
-        pr.remove_jobs(recursive = args.recursive)
+        pr.remove_jobs_silently(recursive = args.recursive)
     else:
         pr.remove(enable = True)
         if not os.listdir(args.project):

--- a/tests/atomistics/job/test_atomistic.py
+++ b/tests/atomistics/job/test_atomistic.py
@@ -30,7 +30,7 @@ class TestAtomisticGenericJob(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "test_job"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_attributes(self):

--- a/tests/atomistics/master/test_murnaghan.py
+++ b/tests/atomistics/master/test_murnaghan.py
@@ -33,7 +33,7 @@ class TestMurnaghan(unittest.TestCase):
         cls.basis = CrystalStructure(
             element="Fe", bravais_basis="fcc", lattice_constant=3.5
         )
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/atomistics/master/test_murnaghan_master_modal.py
+++ b/tests/atomistics/master/test_murnaghan_master_modal.py
@@ -35,7 +35,7 @@ class TestMurnaghan(unittest.TestCase):
         cls.basis = CrystalStructure(
             element="Fe", bravais_basis="bcc", lattice_constant=2.8
         )
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
         # cls.project.remove_jobs(recursive=True)
         # self.project.set_logging_level('INFO')
 
@@ -43,7 +43,7 @@ class TestMurnaghan(unittest.TestCase):
     def tearDownClass(cls):
         file_location = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(file_location, "testing_murnaghan_master_modal"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True, enforce=True)
 
     def test_run(self):

--- a/tests/atomistics/master/test_murnaghan_non_modal.py
+++ b/tests/atomistics/master/test_murnaghan_non_modal.py
@@ -35,7 +35,7 @@ class TestMurnaghan(unittest.TestCase):
         cls.basis = CrystalStructure(
             element="Fe", bravais_basis="bcc", lattice_constant=2.8
         )
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
         # cls.project.remove_jobs(recursive=True)
         # self.project.set_logging_level('INFO')
 
@@ -43,7 +43,7 @@ class TestMurnaghan(unittest.TestCase):
     def tearDownClass(cls):
         file_location = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(file_location, "testing_murnaghan_non_modal"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True, enforce=True)
 
     def test_run(self):

--- a/tests/atomistics/structure/test_pyscal.py
+++ b/tests/atomistics/structure/test_pyscal.py
@@ -26,7 +26,7 @@ class Testpyscal(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "test_job"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_attributes(self):

--- a/tests/base/job/test_childids.py
+++ b/tests/base/job/test_childids.py
@@ -17,7 +17,7 @@ class TestChildids(unittest.TestCase):
     def tearDownClass(cls):
         file_location = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(file_location, "testing_childids"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_childids(self):

--- a/tests/base/project/test_projectPath.py
+++ b/tests/base/project/test_projectPath.py
@@ -50,6 +50,5 @@ class TestProjectPath(unittest.TestCase):
         self.project_path.close()
         self.assertFalse("test_removedirs" in self.project_path.listdir())
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/interactive/test_scipyminimizer.py
+++ b/tests/interactive/test_scipyminimizer.py
@@ -23,7 +23,7 @@ class TestSxExtOptInteractive(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
 
     def test_minimizer(self):
         self.assertEqual(self.minim.minimizer, 'CG')

--- a/tests/interactive/test_sxextoptint.py
+++ b/tests/interactive/test_sxextoptint.py
@@ -28,7 +28,7 @@ class TestSxExtOptInteractive(unittest.TestCase):
     def tearDownClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
         cls.project = Project(os.path.join(cls.file_location, "../static/sxextopt"))
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
 
 
 if __name__ == "__main__":

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -64,7 +64,7 @@ class TestLammps(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "lammps"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_selective_dynamics(self):

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -60,7 +60,7 @@ class TestLammpsInteractive(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "lammps"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_interactive_cells_setter(self):

--- a/tests/quickff_module/test_quickff.py
+++ b/tests/quickff_module/test_quickff.py
@@ -35,7 +35,7 @@ class TestQuickFF(unittest.TestCase):
         def tearDownClass(cls):
             cls.execution_path = os.path.dirname(os.path.abspath(__file__))
             project = Project(os.path.join(cls.execution_path, "test_quickff"))
-            project.remove_jobs(recursive=True)
+            project.remove_jobs_silently(recursive=True)
             project.remove(enable=True)
 
         def setUp(self):

--- a/tests/table/test_datamining.py
+++ b/tests/table/test_datamining.py
@@ -18,7 +18,7 @@ class TestDatamining(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "table"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_get_majority(self):

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
+import mock
 import os
 from pyiron import Project
 from pyiron.atomistics.structure.atoms import Atoms
@@ -20,6 +21,7 @@ class TestProject(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "test_project"))
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_structure_creation(self):
@@ -31,6 +33,15 @@ class TestProject(unittest.TestCase):
         self.assertFalse(all(surface.pbc))
         self.assertIsInstance(self.project.create_structure("Al", "fcc", 4.05), Atoms)
 
+    def test_remove_jobs(self):
+        sample_job = self.project.create_job("ScriptJob", "Sample")
+        sample_job.save()
+        with mock.patch('builtins.input', return_value="n"):
+            self.project.remove_jobs(recursive=True)
+        self.assertEqual(len(self.project.list_nodes()), 1)
+        with mock.patch('builtins.input', return_value="y"):
+            self.project.remove_jobs(recursive=True)
+        self.assertEqual(len(self.project.list_nodes()), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/testing/test_exampleJob_non_modal.py
+++ b/tests/testing/test_exampleJob_non_modal.py
@@ -16,7 +16,7 @@ class TestExampleJob(unittest.TestCase):
         cls.project = Project(
             os.path.join(cls.file_location, "random_testing_non_modal")
         )
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
         cls.project.set_logging_level("INFO")
 
     @classmethod
@@ -24,7 +24,7 @@ class TestExampleJob(unittest.TestCase):
         # print('tear down')
         file_location = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(file_location, "random_testing_non_modal"))
-        project.remove_jobs()
+        project.remove_jobs_silently()
         project.remove(enable=True)
 
     def test_non_modal_run(self):

--- a/tests/testing/test_serialMaster.py
+++ b/tests/testing/test_serialMaster.py
@@ -29,7 +29,7 @@ class TestSerialMaster(unittest.TestCase):
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
         cls.project = Project(os.path.join(cls.file_location, "testing_serial"))
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/testing/test_serialMaster_non_modal.py
+++ b/tests/testing/test_serialMaster_non_modal.py
@@ -31,7 +31,7 @@ class TestSerialMaster(unittest.TestCase):
         cls.project = Project(
             os.path.join(cls.file_location, "testing_serial_non_modal")
         )
-        cls.project.remove_jobs(recursive=True)
+        cls.project.remove_jobs_silently(recursive=True)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/vasp/test_vasp.py
+++ b/tests/vasp/test_vasp.py
@@ -51,7 +51,7 @@ class TestVasp(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "test_vasp"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def setUp(self):

--- a/tests/vasp/test_vasp_import.py
+++ b/tests/vasp/test_vasp_import.py
@@ -19,7 +19,7 @@ class TestVaspImport(unittest.TestCase):
     def tearDownClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.file_location, "vasp_import_testing"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def test_import(self):

--- a/tests/yaff_module/test_yaff.py
+++ b/tests/yaff_module/test_yaff.py
@@ -36,7 +36,7 @@ class TestYaff(unittest.TestCase):
     def tearDownClass(cls):
         cls.execution_path = os.path.dirname(os.path.abspath(__file__))
         project = Project(os.path.join(cls.execution_path, "test_yaff"))
-        project.remove_jobs(recursive=True)
+        project.remove_jobs_silently(recursive=True)
         project.remove(enable=True)
 
     def setUp(self):


### PR DESCRIPTION
As discussed in #843 and in today's meeting, I built a user input call into `Project.remove_jobs()` to confirm the removal:

```python
def remove_jobs(self, recursive=False):
    """
    Remove all jobs in the current project and in all subprojects if recursive=True is selected - see also
    remove_job().

    For safety, the user is asked via input() to confirm the removal. To bypass this
    interactive interruption, use `remove_jobs_silently()`.

    Args:
        recursive (bool): [True/False] delete all jobs in all subprojects - default=False
    """
    if not isinstance(recursive, bool):
        raise ValueError('recursive must be a boolean')
    if not self.view_mode:
        confirmed = None
        while confirmed not in ["y", "n"]:
            if confirmed is None:
                confirmed = input(
                    "Are you sure you want to delete all jobs from "
                    + f"'{self.base_name}'? y/(n)"
                    ).lower()
            else:
                confirmed = input(
                    "Invalid response. Please enter 'y' (yes) or 'n' (no): "
                    ).lower()
        if confirmed == "y":
            # proceed to delete the jobs
            for job_id in self.get_job_ids(recursive=recursive):
                if job_id not in self.get_job_ids(recursive=recursive):
                    continue
                else:
                    try:
                        self.remove_job(job_specifier=job_id)
                        s.logger.debug("Remove job with ID {0} ".format(job_id))
                    except (IndexError, Exception):
                        s.logger.debug(
                            "Could not remove job with ID {0} ".format(job_id)
                        )
        else:
            print(f"No jobs removed from '{self.base_name}'.")
    else:
        raise EnvironmentError("copy_to: is not available in Viewermode !")
```

To leave the tests and notebooks unaffected, I replaced their calls to `remove_jobs` with `remove_jobs_silently`, which does exactly what the original function did.

I added a test for the new "interactive" `remove_jobs` in test_project.py.