### PR TITLE
Simplify setting potentials for VASP

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -270,9 +270,12 @@ class VaspBase(GenericDFTJob):
         if self.structure is None:
             raise ValueError("Can't list potentials unless a structure is set")
         else:
-            return VaspPotentialFile(xc=self.input.potcar["xc"]).find(
+            df = VaspPotentialFile(xc=self.input.potcar["xc"]).find(
                 self.structure.get_species_symbols().tolist()
             )
+            if len(df) > 0:
+                df["Name"] = [n.split("-")[0] for n in df["Name"].values]
+            return df
 
     @property
     def potential_list(self):
@@ -283,7 +286,7 @@ class VaspBase(GenericDFTJob):
                 self.structure.get_species_symbols().tolist()
             )
             if len(df) != 0:
-                return df["Name"]
+                return [n.split("-")[0] for n in df["Name"].values]
             else:
                 return []
 

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -246,6 +246,9 @@ class VaspPotentialSetter(object):
         else:
             raise AttributeError
 
+    def __setitem__(self, key, value):
+        self.__setattr__(key=key, value=value)
+
     def __setattr__(self, key, value):
         if key in self._element_lst:
             self._potential_dict[key] = value
@@ -389,6 +392,19 @@ class Potcar(GenericParameters):
                 )
                 if not (os.path.isfile(el_path)):
                     raise ValueError("such a file does not exist in the pp directory")
+            elif el in self.modified_elements.keys():
+                new_element = self.modified_elements[el]
+                if os.path.isabs(new_element):
+                    el_path = new_element
+                else:
+                    vasp_potentials.add_new_element(
+                        parent_element=el, new_element=new_element
+                    )
+                    el_path = find_potential_file(
+                        path=vasp_potentials.find_default(new_element)["Filename"].values[
+                            0
+                        ][0]
+                    )
             else:
                 el_path = find_potential_file(
                     path=vasp_potentials.find_default(el)["Filename"].values[0][0]
@@ -412,10 +428,7 @@ class Potcar(GenericParameters):
                 self._dataset["Parameter"].append("pot_" + str(i))
                 self._dataset["Value"].append(el_path)
                 self._dataset["Comment"].append("")
-            if el_obj.Abbreviation in self.modified_elements.keys():
-                self.el_path_lst.append(self.modified_elements[el_obj.Abbreviation])
-            else:
-                self.el_path_lst.append(el_path)
+            self.el_path_lst.append(el_path)
 
     def write_file(self, file_name, cwd=None):
         """


### PR DESCRIPTION
Use:

```
job.potential["Al"] = "Al_sv_GW"
job.potential["Ca"] = "Ca_sv_GW"
```

Or:

```
job.potential.Al = "Al_sv_GW"
job.potential.Ca = "Ca_sv_GW"
```

In addition you can list the available potentials with:
```
job.list_potentials()
```
Or get more detailed information with:
```
job.potential_view
```

Finally to change the pseudo potential use:
```
job.input.potcar["xc"] = "LDA"   # "GGA" or "LDA"
```

To mix different pseudo potential functionals you need to specify the absolute path to the corresponding potentials. Anyway mixing different pseudo potential functionals is not recommended.