### PR TITLE
Backwards compatible loading for StructureContainer & tests

### DIFF
--- a/pyiron/atomistics/job/structurecontainer.py
+++ b/pyiron/atomistics/job/structurecontainer.py
@@ -28,6 +28,7 @@ class StructureContainer(AtomisticGenericJob):
     """
 
     __version__ = "0.1.0"
+    __hdf_version__ = "0.2.0"
 
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
@@ -131,12 +132,17 @@ class StructureContainer(AtomisticGenericJob):
             structure.to_hdf(hdf, group_name = "structure_{}".format(i))
 
     def from_hdf(self, hdf = None, group_name = None):
-        GenericJob.from_hdf(self, hdf = hdf, group_name = group_name)
+        if self.project_hdf5['HDF_VERSION'] == "0.1.0":
+            super().from_hdf(hdf=hdf, group_name=group_name)
+            with self.project_hdf5.open("input") as hdf5_input:
+                self.structure = Atoms().from_hdf(hdf5_input)
+        else:
+            GenericJob.from_hdf(self, hdf = hdf, group_name = group_name)
 
-        self.structure_lst.clear()
+            self.structure_lst.clear()
 
-        hdf = self.project_hdf5["structures"]
-        for group in sorted(hdf.list_groups()):
-            structure = Atoms()
-            structure.from_hdf(hdf, group_name = group)
-            self.structure_lst.append(structure)
+            hdf = self.project_hdf5["structures"]
+            for group in sorted(hdf.list_groups()):
+                structure = Atoms()
+                structure.from_hdf(hdf, group_name = group)
+                self.structure_lst.append(structure)

--- a/pyiron/atomistics/job/structurecontainer.py
+++ b/pyiron/atomistics/job/structurecontainer.py
@@ -27,11 +27,10 @@ class StructureContainer(AtomisticGenericJob):
     :meth:`.run` is called.
     """
 
-    __version__ = "0.1.0"
-    __hdf_version__ = "0.2.0"
-
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
+        self.__version__ = "0.2.0"
+        self.__hdf_version__ = "0.2.0"
         self._structure_lst = InputList(table_name = "structures")
         self.server.run_mode.interactive = True
 
@@ -132,7 +131,11 @@ class StructureContainer(AtomisticGenericJob):
             structure.to_hdf(hdf, group_name = "structure_{}".format(i))
 
     def from_hdf(self, hdf = None, group_name = None):
-        if self.project_hdf5['HDF_VERSION'] == "0.1.0":
+        if group_name:
+            hdf_version = self.project_hdf5[group_name]['HDF_VERSION']
+        else:
+            hdf_version = self.project_hdf5['HDF_VERSION']
+        if hdf_version == "0.1.0":
             super().from_hdf(hdf=hdf, group_name=group_name)
             with self.project_hdf5.open("input") as hdf5_input:
                 self.structure = Atoms().from_hdf(hdf5_input)

--- a/pyiron/atomistics/job/structurecontainer.py
+++ b/pyiron/atomistics/job/structurecontainer.py
@@ -131,10 +131,14 @@ class StructureContainer(AtomisticGenericJob):
             structure.to_hdf(hdf, group_name = "structure_{}".format(i))
 
     def from_hdf(self, hdf = None, group_name = None):
-        if group_name:
-            hdf_version = self.project_hdf5[group_name]['HDF_VERSION']
-        else:
-            hdf_version = self.project_hdf5['HDF_VERSION']
+        try:
+            if group_name:
+                hdf_version = self.project_hdf5[group_name]["HDF_VERSION"]
+            else:
+                hdf_version = self.project_hdf5["HDF_VERSION"]
+        except ValueError:
+            # old versions didn't use to set a HDF version
+            hdf_version = "0.1.0"
         if hdf_version == "0.1.0":
             super().from_hdf(hdf=hdf, group_name=group_name)
             with self.project_hdf5.open("input") as hdf5_input:

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1550,7 +1550,6 @@ class GenericJob(JobCore):
         Internal helper function to load type and version from HDF5 file root
         """
         self.__obj_type__ = self._hdf5["TYPE"]
-        self.__hdf_version__ = self._hdf5["HDF_VERSION"]
         if self._executable:
             try:
                 self.executable.version = self._hdf5["VERSION"]

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1550,6 +1550,7 @@ class GenericJob(JobCore):
         Internal helper function to load type and version from HDF5 file root
         """
         self.__obj_type__ = self._hdf5["TYPE"]
+        self.__hdf_version__ = self._hdf5["HDF_VERSION"]
         if self._executable:
             try:
                 self.executable.version = self._hdf5["VERSION"]

--- a/tests/backwards/test_sphinx_load.py
+++ b/tests/backwards/test_sphinx_load.py
@@ -1,6 +1,8 @@
 import sys
 from pyiron import Project, __version__
 pr = Project("tests/static/backwards/")
-for job in pr.iter_jobs(recursive = True):
-    if job.name == "sphinx": job.run()
+for job in pr.iter_jobs(recursive = True, convert_to_object = False):
+    if job.name == "sphinx":
+        job = job.to_object()
+        job.run()
     print("job {} loaded from {}".format(job.id, sys.argv[0]))

--- a/tests/backwards/test_structure_container_load.py
+++ b/tests/backwards/test_structure_container_load.py
@@ -1,5 +1,6 @@
 from pyiron import Project, __version__
 pr = Project("tests/static/backwards")
-for job in pr.iter_jobs(recursive = True):
-    if job.name == "structurecontainer":
+for job in pr.iter_jobs(recursive = True, convert_to_object = False):
+    if job.name == "structure_container":
+        job = job.to_object()
         job.run()

--- a/tests/backwards/test_structure_container_load.py
+++ b/tests/backwards/test_structure_container_load.py
@@ -1,0 +1,5 @@
+from pyiron import Project, __version__
+pr = Project("tests/static/backwards")
+for job in pr.iter_jobs(recursive = True):
+    if job.name == "structurecontainer":
+        job.run()

--- a/tests/backwards/test_structure_container_save.py
+++ b/tests/backwards/test_structure_container_save.py
@@ -3,6 +3,6 @@ pr = Project(
     "tests/static/backwards/V{}".format(__version__).replace(".", "_")
 )
 structure = pr.create_ase_bulk("Al")
-job = pr.create_job(pr.job_type.StructureContainer, "structurecontainer")
+job = pr.create_job(pr.job_type.StructureContainer, "structure_container")
 job.structure = structure
 job.save()

--- a/tests/backwards/test_structure_container_save.py
+++ b/tests/backwards/test_structure_container_save.py
@@ -1,0 +1,8 @@
+from pyiron import Project, __version__
+pr = Project(
+    "tests/static/backwards/V{}".format(__version__).replace(".", "_")
+)
+structure = pr.create_ase_bulk("Al")
+job = pr.create_job(pr.job_type.StructureContainer, "structurecontainer")
+job.structure = structure
+job.save()


### PR DESCRIPTION
The serialization format for `StructureContainer` changed due to #873 and I didn't catch that.  This bumps the HDF version for that job and adds a compatible `from_hdf`.