### PR TITLE
Vasp potential peeking

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -9,7 +9,8 @@ import subprocess
 import numpy as np
 
 from pyiron.dft.job.generic import GenericDFTJob
-from pyiron.vasp.potential import VaspPotential, VaspPotentialFile, VaspPotentialSetter, Potcar
+from pyiron.vasp.potential import VaspPotential, VaspPotentialFile, VaspPotentialSetter, Potcar, \
+    strip_xc_from_potential_name
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
 from pyiron.base.settings.generic import Settings
 from pyiron.base.generic.parameters import GenericParameters
@@ -271,7 +272,7 @@ class VaspBase(GenericDFTJob):
                 self.structure.get_species_symbols().tolist()
             )
             if len(df) > 0:
-                df["Name"] = [n.split("-")[0] for n in df["Name"].values]
+                df["Name"] = [strip_xc_from_potential_name(n) for n in df["Name"].values]
             return df
 
     @property
@@ -283,7 +284,7 @@ class VaspBase(GenericDFTJob):
                 self.structure.get_species_symbols().tolist()
             )
             if len(df) != 0:
-                return [n.split("-")[0] for n in df["Name"].values]
+                return [strip_xc_from_potential_name(n) for n in df["Name"].values]
             else:
                 return []
 

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -19,7 +19,7 @@ from pyiron.vasp.structure import read_atoms, write_poscar, vasp_sorter
 from pyiron.vasp.vasprun import Vasprun as Vr
 from pyiron.vasp.vasprun import VasprunError
 from pyiron.vasp.volumetric_data import VaspVolumetricData
-from pyiron.vasp.potential import get_enmax_among_species
+from pyiron.vasp.potential import get_enmax_among_potentials
 from pyiron.dft.waves.electronic import ElectronicStructure
 from pyiron.dft.waves.bandstructure import Bandstructure
 import warnings
@@ -80,7 +80,7 @@ class VaspBase(GenericDFTJob):
         self._output_parser = Output()
         self._potential = VaspPotentialSetter([])
         self._compress_by_default = True
-        self.get_enmax_among_species = get_enmax_among_species
+        self.get_enmax_among_species = get_enmax_among_potentials
         s.publication_add(self.publication)
 
     @property

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -277,16 +277,7 @@ class VaspBase(GenericDFTJob):
 
     @property
     def potential_list(self):
-        if self.structure is None:
-            raise ValueError("Can't list potentials unless a structure is set")
-        else:
-            df = VaspPotentialFile(xc=self.input.potcar["xc"]).find(
-                self.structure.get_species_symbols().tolist()
-            )
-            if len(df) != 0:
-                return [strip_xc_from_potential_name(n) for n in df["Name"].values]
-            else:
-                return []
+        return list(self.potential_view["Name"].values)
 
     @property
     def publication(self):

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -287,8 +287,8 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
-    warnings.warn("get_enmax_among_species is deprecated as of v0.3.0. Please use get_enmax_among_potentials and note "
-                  "the adjustment to the signature (*args instead of list)")
+    warnings.warn(("get_enmax_among_species is deprecated as of v0.3.0. Please use get_enmax_among_potentials and note "
+                   + "the adjustment to the signature (*args instead of list)"), DeprecationWarning)
     return get_enmax_among_potentials(*symbol_lst, return_list=return_list, xc=xc)
 
 

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -328,8 +328,8 @@ def get_enmax_among_potentials(*names, return_list=False, xc="PBE"):
         ][0]
 
     enmax_lst = []
-    for name in names:
-        with open(find_potential_file(path=_get_potcar_filename(name, xc))) as pf:
+    for n in names:
+        with open(find_potential_file(path=_get_potcar_filename(n, xc))) as pf:
             for i, line in enumerate(pf):
                 if i == 14:
                     encut_str = line.split()[2][:-1]

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -8,6 +8,7 @@ import posixpath
 import numpy as np
 import pandas
 import tables
+import warnings
 from pyiron.base.generic.parameters import GenericParameters
 from pyiron.base.settings.generic import Settings
 from pyiron.atomistics.job.potentials import PotentialAbstract, find_potential_file_base
@@ -272,6 +273,8 @@ def find_potential_file(path):
 
 def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
     """
+    DEPRECATED: Please use `get_enmax_among_potentials`.
+
     Given a list of species symbols, finds the largest applicable encut.
 
     Args:
@@ -282,6 +285,27 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
 
     Returns:
         (float): The largest ENMAX among the POTCAR files for all the species.
+        [optional](list): The ENMAX value corresponding to each species.
+    """
+    warnings.warn("get_enmax_among_species is deprecated as of v0.3.0. Please use get_enmax_among_potentials and note "
+                  "the adjustment to the signature (*args instead of list)")
+    return get_enmax_among_potentials(*symbol_lst, return_list=return_list, xc=xc)
+
+
+def get_enmax_among_potentials(*names, return_list=False, xc="PBE"):
+    """
+    Given potential names (e.g. 'Al_sv_GW') or elemental symbols, look over all the corresponding POTCAR files and find
+    the largest ENMAX value.
+
+    Args:
+        *names (str): Names of potentials or elemental symbols
+        return_list (bool): Whether to return the list of all ENMAX values (in the same order as `names` as a second
+            return value after providing the largest value). (Default is False.)
+        xc ("GGA"/"PBE"/"LDA"): The exchange correlation functional for which the POTCARs were generated.
+            (Default is "PBE".)
+
+    Returns:
+        (float): The largest ENMAX among the POTCAR files for all the requested names.
         [optional](list): The ENMAX value corresponding to each species.
     """
     def _get_just_element_from_name(name):
@@ -304,8 +328,8 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         ][0]
 
     enmax_lst = []
-    for symbol in symbol_lst:
-        with open(find_potential_file(path=_get_potcar_filename(symbol, xc))) as pf:
+    for name in names:
+        with open(find_potential_file(path=_get_potcar_filename(name, xc))) as pf:
             for i, line in enumerate(pf):
                 if i == 14:
                     encut_str = line.split()[2][:-1]

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -284,7 +284,6 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
-    pot_path_dict = Potcar.pot_path_dict
 
     enmax_lst = []
     vpf = VaspPotentialFile(xc=xc)

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -292,9 +292,10 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
 
     def _get_index_of_exact_match(name, potential_names):
         try:
-            return np.argwhere(name == _strip_xc_from_name(pn) for pn in potential_names)[0, 0]
+            return np.argwhere([name == _strip_xc_from_name(pn) for pn in potential_names])[0, 0]
         except IndexError:
-            raise("Couldn't find {} among potential names for {}".format(name, _get_just_element_from_name(name)))
+            raise ValueError("Couldn't find {} among potential names for {}".format(name,
+                                                                                    _get_just_element_from_name(name)))
 
     def _get_potcar_filename(name, exch_corr):
         potcar_table = VaspPotentialFile(xc=exch_corr).find(_get_just_element_from_name(name))

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -284,15 +284,23 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
+    def _get_potcar_filename(sym, xc):
+        # def _get_just_element(sym):
+        #     return sym.split('_')[0]
+        #
+        # def _get_index_of_first_match(pattern, candidate_list):
+        #     return np.argwhere(pattern in candidate for candidate in candidate_list)[0, 0]
+        #
+        # potcar_table = VaspPotentialFile(xc=xc).find(_get_just_element(symbol))
+        # return potcar_table['Filename'].values[
+        #     _get_index_of_first_match(sym, potcar_table['Name'].values)
+        # ][0]
+        return '-'.join([sym, xc.lower()])
 
     enmax_lst = []
-    vpf = VaspPotentialFile(xc=xc)
 
     for symbol in symbol_lst:
-        potcar_file = find_potential_file(
-            path=vpf.find_default(symbol)['Filename'].values[0][0]
-        )
-        with open(potcar_file) as pf:
+        with open(find_potential_file(path=_get_potcar_filename(symbol, xc))) as pf:
             for i, line in enumerate(pf):
                 if i == 14:
                     encut_str = line.split()[2][:-1]

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -342,6 +342,9 @@ def get_enmax_among_potentials(*names, return_list=False, xc="PBE"):
 
 
 def strip_xc_from_potential_name(name):
+    if len(name.split('-')) > 2:
+        raise ValueError('Expected potential names to have a single dash before the XC flag, e.g. "Al_GW-pbe", but got'
+                         '{}. Please check for a typo or re-evaluate POTCAR name formatting rules.'.format(name))
     return name.split('-')[0]
 
 

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -342,9 +342,6 @@ def get_enmax_among_potentials(*names, return_list=False, xc="PBE"):
 
 
 def strip_xc_from_potential_name(name):
-    if len(name.split('-')) > 2:
-        raise ValueError('Expected potential names to have a single dash before the XC flag, e.g. "Al_GW-pbe", but got'
-                         '{}. Please check for a typo or re-evaluate POTCAR name formatting rules.'.format(name))
     return name.split('-')[0]
 
 

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -24,8 +24,7 @@ class TestPotential(unittest.TestCase):
         self.assertRaises(ValueError, get_enmax_among_potentials, symbol_lst=['Fe'], xc='FOO')
 
     def test_strip_xc_from_potential_name(self):
-        self.assertEqual(strip_xc_from_potential_name('X_pv-pbe'), 'X_pv')
-        self.assertRaises(ValueError, strip_xc_from_potential_name, 'has-multiple-dashes')
+        self.assertEqual(strip_xc_from_potential_name('X_pv-gga-pbe'), 'X_pv')
 
 
 if __name__ == "__main__":

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -4,7 +4,7 @@
 
 import unittest
 import os
-from pyiron.vasp.potential import get_enmax_among_species
+from pyiron.vasp.potential import get_enmax_among_potentials
 
 
 class TestPotential(unittest.TestCase):
@@ -13,15 +13,15 @@ class TestPotential(unittest.TestCase):
     def setUpClass(cls):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
 
-    def test_get_enmax_among_species(self):
-        float_out = get_enmax_among_species(['Fe'], return_list=False)
+    def test_get_enmax_among_potentials(self):
+        float_out = get_enmax_among_potentials(['Fe'], return_list=False)
         self.assertTrue(isinstance(float_out, float))
 
-        tuple_out = get_enmax_among_species(['Fe'], return_list=True)
+        tuple_out = get_enmax_among_potentials(['Fe'], return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
-        self.assertRaises(KeyError, get_enmax_among_species, symbol_lst=['X'])
-        self.assertRaises(ValueError, get_enmax_among_species, symbol_lst=['Fe'], xc='FOO')
+        self.assertRaises(KeyError, get_enmax_among_potentials, symbol_lst=['X'])
+        self.assertRaises(ValueError, get_enmax_among_potentials, symbol_lst=['Fe'], xc='FOO')
 
 
 if __name__ == "__main__":

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -17,11 +17,11 @@ class TestPotential(unittest.TestCase):
         float_out = get_enmax_among_potentials('Fe', return_list=False)
         self.assertTrue(isinstance(float_out, float))
 
-        tuple_out = get_enmax_among_potentials('Fe', 'Fe_pv', return_list=True)
+        tuple_out = get_enmax_among_potentials('Fe', return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
-        self.assertRaises(KeyError, get_enmax_among_potentials, symbol_lst=['X'])
-        self.assertRaises(ValueError, get_enmax_among_potentials, symbol_lst=['Fe'], xc='FOO')
+        self.assertRaises(KeyError, get_enmax_among_potentials, symbols=['X'])
+        self.assertRaises(ValueError, get_enmax_among_potentials, symbols=['Fe'], xc='FOO')
 
     def test_strip_xc_from_potential_name(self):
         self.assertEqual(strip_xc_from_potential_name('X_pv-gga-pbe'), 'X_pv')

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -14,10 +14,10 @@ class TestPotential(unittest.TestCase):
         cls.file_location = os.path.dirname(os.path.abspath(__file__))
 
     def test_get_enmax_among_potentials(self):
-        float_out = get_enmax_among_potentials(['Fe'], return_list=False)
+        float_out = get_enmax_among_potentials('Fe', return_list=False)
         self.assertTrue(isinstance(float_out, float))
 
-        tuple_out = get_enmax_among_potentials(['Fe'], return_list=True)
+        tuple_out = get_enmax_among_potentials('Fe', return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
         self.assertRaises(KeyError, get_enmax_among_potentials, symbol_lst=['X'])

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -17,7 +17,7 @@ class TestPotential(unittest.TestCase):
         float_out = get_enmax_among_potentials('Fe', return_list=False)
         self.assertTrue(isinstance(float_out, float))
 
-        tuple_out = get_enmax_among_potentials('Fe', return_list=True)
+        tuple_out = get_enmax_among_potentials('Fe', 'Fe_pv', return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
         self.assertRaises(KeyError, get_enmax_among_potentials, symbol_lst=['X'])

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -20,7 +20,7 @@ class TestPotential(unittest.TestCase):
         tuple_out = get_enmax_among_potentials('Fe', return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
-        self.assertRaises(KeyError, get_enmax_among_potentials, 'X')
+        self.assertRaises(ValueError, get_enmax_among_potentials, 'X')
         self.assertRaises(ValueError, get_enmax_among_potentials, 'Fe', xc='FOO')
 
     def test_strip_xc_from_potential_name(self):

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -20,8 +20,8 @@ class TestPotential(unittest.TestCase):
         tuple_out = get_enmax_among_potentials('Fe', return_list=True)
         self.assertTrue(isinstance(tuple_out, tuple))
 
-        self.assertRaises(KeyError, get_enmax_among_potentials, symbols=['X'])
-        self.assertRaises(ValueError, get_enmax_among_potentials, symbols=['Fe'], xc='FOO')
+        self.assertRaises(KeyError, get_enmax_among_potentials, 'X')
+        self.assertRaises(ValueError, get_enmax_among_potentials, 'Fe', xc='FOO')
 
     def test_strip_xc_from_potential_name(self):
         self.assertEqual(strip_xc_from_potential_name('X_pv-gga-pbe'), 'X_pv')

--- a/tests/vasp/test_potential.py
+++ b/tests/vasp/test_potential.py
@@ -4,7 +4,7 @@
 
 import unittest
 import os
-from pyiron.vasp.potential import get_enmax_among_potentials
+from pyiron.vasp.potential import get_enmax_among_potentials, strip_xc_from_potential_name
 
 
 class TestPotential(unittest.TestCase):
@@ -22,6 +22,10 @@ class TestPotential(unittest.TestCase):
 
         self.assertRaises(KeyError, get_enmax_among_potentials, symbol_lst=['X'])
         self.assertRaises(ValueError, get_enmax_among_potentials, symbol_lst=['Fe'], xc='FOO')
+
+    def test_strip_xc_from_potential_name(self):
+        self.assertEqual(strip_xc_from_potential_name('X_pv-pbe'), 'X_pv')
+        self.assertRaises(ValueError, strip_xc_from_potential_name, 'has-multiple-dashes')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the ability to pull ENMAX based on a bunch of atomic species to pull it based on a bunch of pseudopotential names, ala [pull request 908](https://github.com/pyiron/pyiron/pull/908).

e.g.

```
from pyiron.vasp.potential import get_enmax_among_potentials
get_enmax_among_species(['Mg', 'Al_sv_GW', 'Ca_pv'], return_list=True)
> (411.109, [200.0, 411.109, 119.559])
```