### PR TITLE
Use rotation matrix in vcsgc too

### DIFF
--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -742,6 +742,7 @@ class LammpsBase(AtomisticGenericJob):
             window_moves (int): The number of times the sampling window is moved during one MC cycle. (Default is None,
                 number of moves is determined automatically.)
         """
+        rotation_matrix = self._get_rotation_matrix(pressure=pressure)
         if mu is None:
             mu = {}
             for el in self.input.potential.get_element_lst():
@@ -773,6 +774,7 @@ class LammpsBase(AtomisticGenericJob):
             initial_temperature=initial_temperature,
             langevin=langevin,
             job_name=self.job_name,
+            rotation_matrix=rotation_matrix
         )
 
     # define hdf5 input and output

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -609,6 +609,7 @@ class LammpsControl(GenericParameters):
         initial_temperature=None,
         langevin=False,
         job_name="",
+        rotation_matrix=None
     ):
         """
         Run variance-constrained semi-grand-canonical MD/MC for a binary system. In addition to VC-SGC arguments, all
@@ -646,6 +647,7 @@ class LammpsControl(GenericParameters):
                 determined automatically.)
             window_moves (int): The number of times the sampling window is moved during one MC cycle. (Default is None,
                 number of moves is determined automatically.)
+            rotation_matrix (numpy.ndarray): The rotation matrix from the pyiron to Lammps coordinate frame.
         """
         self.calc_md(
             temperature=temperature,
@@ -660,6 +662,7 @@ class LammpsControl(GenericParameters):
             initial_temperature=initial_temperature,
             langevin=langevin,
             job_name=job_name,
+            rotation_matrix=rotation_matrix
         )
 
         if self["units"] not in LAMMPS_UNIT_CONVERSIONS.keys():


### PR DESCRIPTION
Without it `lammps.base.calc_vcsgc` fails for isobaric calculations because the pressure value isn't iterable.