### PR TITLE
Pipeline restart fix + non-generic master job name

### DIFF
--- a/pyiron/atomistics/master/parallel.py
+++ b/pyiron/atomistics/master/parallel.py
@@ -163,7 +163,7 @@ def pipe(project, job, step_lst, delete_existing_job=False):
     Returns:
         FlexibleMaster:
     """
-    job_lst_master = project.create_job(project.job_type.FlexibleMaster, 'lstmaster', delete_existing_job=delete_existing_job)
+    job_lst_master = project.create_job(project.job_type.FlexibleMaster, job.job_name + '_lstmaster', delete_existing_job=delete_existing_job)
     if job_lst_master.status.finished:
         return job_lst_master
     else:

--- a/pyiron/base/job/generic.py
+++ b/pyiron/base/job/generic.py
@@ -1086,7 +1086,7 @@ class GenericJob(JobCore):
             job.ref_job = self
         return job
 
-    def create_pipeline(self, step_lst):
+    def create_pipeline(self, step_lst, delete_existing_job=False):
         """
         Create a job pipeline
 
@@ -1096,7 +1096,7 @@ class GenericJob(JobCore):
         Returns:
             FlexibleMaster:
         """
-        return self.project.create_pipeline(job=self, step_lst=step_lst)
+        return self.project.create_pipeline(job=self, step_lst=step_lst, delete_existing_job=delete_existing_job)
 
     def update_master(self):
         """

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -620,4 +620,4 @@ class Project(ProjectCore):
         Returns:
             FlexibleMaster:
         """
-        return pipe(project=self, job=job, step_lst=step_lst, delete_existing_job=False)
+        return pipe(project=self, job=job, step_lst=step_lst, delete_existing_job=delete_existing_job)


### PR DESCRIPTION
There was a small bug in the pipeline restart functionality + it was not possible to run more than one pipeline in the project due to the non-unique name of the master job. This is fixed now by adding the template job name as a prefix.