### PR TITLE
Int64 is int too

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2891,7 +2891,7 @@ class Atoms(ASEAtoms):
     __mul__ = repeat
 
     def __imul__(self, vec):
-        if isinstance(vec, int):
+        if isinstance(vec, (int, np.integer)):
             vec = [vec] * self.dimension
         initial_length = len(self)
         if not hasattr(vec, '__len__'):

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -687,6 +687,7 @@ class TestAtoms(unittest.TestCase):
                 -1 * np.ones(len(basis.select_index("O"))),
             )
         )
+        self.assertEqual(8 * len(self.CO2), len(self.CO2.repeat(np.int64(2))))
 
     def test_boundary(self):
         cell = 2.2 * np.identity(3)


### PR DESCRIPTION
I was iterating over a `np.arange` for size convergence and ran into this. I've run into it before under the same circumstances, but I finally got tired enough of converting from `np.int64` to `int` to do something about it 😝 