### PR TITLE
Append atoms

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2599,7 +2599,7 @@ class Atoms(ASEAtoms):
             return dist
 
     def append(self, atom):
-        if isinstance(atom, Atom) or isinstance(atom, ASEAtom):
+        if isinstance(atom, ASEAtom):
             super(Atoms, self).append(atom=atom)
         else:
             if atom.pbc.all() and np.isclose(atom.get_volume(), 0):

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2598,6 +2598,14 @@ class Atoms(ASEAtoms):
         else:
             return dist
 
+    def append(self, atom):
+        if isinstance(atom, Atom) or isinstance(atom, ASEAtom):
+            super(Atoms, self).append(atom=atom)
+        else:
+            if atom.pbc.all() and np.isclose(atom.get_volume(), 0):
+                atom.cell = self.cell
+            self += atom
+
     def extend(self, other):
         """
         Extend atoms object by appending atoms from *other*. (Extending the ASE function)

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -2602,9 +2602,11 @@ class Atoms(ASEAtoms):
         if isinstance(atom, ASEAtom):
             super(Atoms, self).append(atom=atom)
         else:
-            if atom.pbc.all() and np.isclose(atom.get_volume(), 0):
-                atom.cell = self.cell
-            self += atom
+            new_atoms = atom.copy()
+            if new_atoms.pbc.all() and np.isclose(new_atoms.get_volume(), 0):
+                new_atoms.cell = self.cell
+                new_atoms.pbc = self.pbc
+            self += new_atoms
 
     def extend(self, other):
         """

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1244,6 +1244,18 @@ class TestAtoms(unittest.TestCase):
         structure += carbon
         self.assertEqual(carbon.indices[0], 0)
 
+    def test_append(self):
+        a_0 = 2.86
+        structure = create_structure('Fe', 'bcc', a_0)
+        carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]], pbc=True)
+        with warnings.catch_warnings(record=True) as w:
+            structure.append(carbon)
+            self.assertEqual(len(w), 0)
+            structure = create_structure('Fe', 'bcc', a_0)
+            carbon.cell[0,0] = 0.5
+            structure.append(carbon)
+            self.assertEqual(len(w), 1)
+
     def test__delitem__(self):
         cell = np.eye(3) * 10.0
         basis_0 = Atoms(["O"], scaled_positions=[[0.5, 0.5, 0.5]], cell=cell)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1252,7 +1252,7 @@ class TestAtoms(unittest.TestCase):
             structure.append(carbon)
             self.assertEqual(len(w), 0)
             structure = create_structure('Fe', 'bcc', a_0)
-            carbon.cell[0,0] = 0.5
+            carbon.cell = np.random.rand(3)
             structure.append(carbon)
             self.assertEqual(len(w), 1)
 


### PR DESCRIPTION
Discussed in [this issue](https://github.com/pyiron/pyiron/issues/951). The warning is not raised if the cell is periodic with no volume and `append` is used.

Closes #951 