### PR TITLE
Changed kpoints per reciprocal angstrom

### DIFF
--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -91,7 +91,7 @@ class GenericDFTJob(AtomisticGenericJob):
         latlens = np.linalg.norm(cell, axis=-1)
         kmesh = np.rint( 2 * np.pi / latlens * kpoints_per_reciprocal_angstrom)
         if kmesh.min() <= 0:
-            print("Calculated kmesh was 0 for at least one axis, setting it to 1 instead")
+            self._logger.warning("Calculated kmesh was 0 for at least one axis, setting it to 1 instead)
             kmesh[kmesh==0] = 1
         return [int(k) for k in kmesh]
 

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -91,7 +91,7 @@ class GenericDFTJob(AtomisticGenericJob):
         latlens = np.linalg.norm(cell, axis=-1)
         kmesh = np.rint( 2 * np.pi / latlens * kpoints_per_reciprocal_angstrom)
         if kmesh.min() <= 0:
-            self._logger.warning("Calculated kmesh was 0 for at least one axis, setting it to 1 instead)
+            self._logger.warning("Calculated kmesh was 0 for at least one axis, setting it to 1 instead")
             kmesh[kmesh==0] = 1
         return [int(k) for k in kmesh]
 

--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -81,7 +81,7 @@ class GenericDFTJob(AtomisticGenericJob):
             get k-mesh density according to the box size.
 
             Args:
-                kpoints_per_reciprocal_angstrom: (float) number of k-points per reciprocal angstrom (i.e. per 2*pi*box_length)
+                kpoints_per_reciprocal_angstrom: (float) number of k-points per reciprocal angstrom (i.e. per 2*pi / box_length)
                 cell: (list/ndarray) 3x3 cell. If not set, the current cell is used.
         """
         if cell is None:
@@ -91,7 +91,8 @@ class GenericDFTJob(AtomisticGenericJob):
         latlens = np.linalg.norm(cell, axis=-1)
         kmesh = np.rint( 2 * np.pi / latlens * kpoints_per_reciprocal_angstrom)
         if kmesh.min() <= 0:
-            raise AssertionError("kpoint per angstrom too low")
+            print("Calculated kmesh was 0 for at least one axis, setting it to 1 instead")
+            kmesh[kmesh==0] = 1
         return [int(k) for k in kmesh]
 
     @property


### PR DESCRIPTION
kpoints per reciprocal angstrom threw an error if the resulting kpoint mesh was 0 for an axis. I am not sure about the reason for this behavior, but for me it made more sense to set it to 1 kpoint in this case. If there was some special reason for throwing an error I think it would be good idea to make that behavior optional.
Also corrected the function documentation to be consistent with the actual function.