### PR TITLE
flexible formats for force constants in HessianJob

### DIFF
--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -22,11 +22,6 @@ class HessianJob(GenericInteractive):
         self.__version__ = "0.0.1"
         self.__name__ = "HessianJob"
         self.server.run_mode.interactive = True
-        # self.interactive_cache = {
-        #     "forces": [],
-        #     "positions": [],
-        #     "energy_pot": []
-        # }
         self._force_constants = None
         self._reference_structure = None
         self._next_positions = None

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -18,7 +18,7 @@ __date__ = "Feb 20, 2020"
 
 class HessianJob(GenericInteractive):
     def __init__(self, project, job_name):
-        super(GenericInteractive, self).__init__(project, job_name)
+        super(HessianJob, self).__init__(project, job_name)
         self.__version__ = "0.0.1"
         self.__name__ = "HessianJob"
         self.server.run_mode.interactive = True

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -21,6 +21,7 @@ class HessianJob(GenericInteractive):
         super(GenericInteractive, self).__init__(project, job_name)
         self.__version__ = "0.0.1"
         self.__name__ = "HessianJob"
+        self.server.run_mode.interactive = True
         self.interactive_cache = {
             "forces": [],
             "positions": [],
@@ -54,7 +55,8 @@ class HessianJob(GenericInteractive):
 
     def set_reference_structure(self, structure):
         self._reference_structure = structure
-        self.structure = structure
+        if self.structure is None:
+            self.structure = structure
 
     def interactive_position_setter(self, positions):
         positions -= self._reference_structure.positions

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -58,9 +58,10 @@ class HessianJob(GenericInteractive):
 
     def interactive_position_setter(self, positions):
         self.structure.positions = positions.copy()
-        positions -= self._reference_structure.positions
-        positions[positions > self._reference_structure.cell[0, 0] / 2] -= self._reference_structure.cell[0, 0]
-        positions[positions < -self._reference_structure.cell[0, 0] / 2] += self._reference_structure.cell[0, 0]
+        self._next_positions = self.structure.get_scaled_positions()
+        self._next_positions -= self._reference_structure.get_scaled_positions()
+        self._next_positions -= np.rint(self._next_positions)
+        self._next_positions = np.einsum('ji,ni->nj', self.structure.cell, self._next_positions)
         self._next_positions = positions
 
     def validate_ready_to_run(self):

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -35,7 +35,10 @@ class HessianJob(GenericInteractive):
         if len(np.array([force_constants]).flatten())==1:
             self._force_constants = force_constants*np.eye(3*n_atom)
             return
-        elif len(np.array(force_constants).flatten())==n_atom**2:
+        elif np.array(force_constants).shape==(3*n_atom, 3*n_atom):
+            self._force_constants = force_constants
+            return
+        elif np.array(force_constants).shape==(n_atom, n_atom):
             na = np.newaxis
             self._force_constants = (np.array(force_constants)[:,na,:,na]*np.eye(3)[na,:,na,:]).flatten()
             return

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -54,9 +54,9 @@ class HessianJob(GenericInteractive):
         raise AssertionError('force constant shape not recognized')
 
     def set_reference_structure(self, structure):
-        self._reference_structure = structure
+        self._reference_structure = structure.copy()
         if self.structure is None:
-            self.structure = structure
+            self.structure = structure.copy()
 
     def interactive_position_setter(self, positions):
         self.structure.positions = positions.copy()

--- a/pyiron/thermodynamics/hessian.py
+++ b/pyiron/thermodynamics/hessian.py
@@ -34,24 +34,22 @@ class HessianJob(GenericInteractive):
         n_atom = len(self.structure.positions)
         if len(np.array([force_constants]).flatten())==1:
             self._force_constants = force_constants*np.eye(3*n_atom)
-            return
         elif np.array(force_constants).shape==(3*n_atom, 3*n_atom):
             self._force_constants = force_constants
-            return
         elif np.array(force_constants).shape==(n_atom, n_atom):
             na = np.newaxis
             self._force_constants = (np.array(force_constants)[:,na,:,na]*np.eye(3)[na,:,na,:]).flatten()
-            return
-        force_shape = np.shape(force_constants)
-        if len(force_shape)==4:
+        elif len(np.shape(force_constants))==4:
+            force_shape = np.shape(force_constants)
             if force_shape[2]==3 and force_shape[3]==3:
                 force_reshape = force_shape[0] * force_shape[2]
                 self._force_constants = np.transpose(force_constants, (0, 2, 1, 3)).reshape((force_reshape, force_reshape))
-                return
             elif force_shape[1]==3 and force_shape[3]==3:
                 self._force_constants = np.array(force_constants).reshape(3*n_atom, 3*n_atom)
-                return
-        raise AssertionError('force constant shape not recognized')
+            else:
+                raise AssertionError('force constant shape not recognized')
+        else:
+            raise AssertionError('force constant shape not recognized')
 
     def set_reference_structure(self, structure):
         self._reference_structure = structure.copy()

--- a/tests/thermodynamics/test_hessianJob.py
+++ b/tests/thermodynamics/test_hessianJob.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import os
+import unittest
+import numpy as np
+from pyiron_base import Project
+from pyiron.atomistics.structure.atoms import Atoms
+
+
+class TestHessianJob(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.file_location = os.path.dirname(os.path.abspath(__file__))
+        cls.project = Project(
+            os.path.join(cls.file_location, "hessian_class")
+        )
+        cls.job = cls.project.create_job(
+            "HessianJob", "job_test_hessian"
+        )
+        structure = Atoms(
+            positions=[[0, 0, 0], [1, 1, 1]], elements=["Fe", "Fe"], cell=2 * np.eye(3)
+        )
+        cls.job.set_reference_structure(structure)
+        cls.job.structure.positions[0,0] = 0.1
+        cls.job.set_force_constants(1)
+        cls.job.run()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.job.interactive_close()
+        cls.job.remove()
+        cls.project.remove(enable=True)
+
+    def test_forces(self):
+        self.assertAlmostEqual(self.job.output.forces[0,0,0], -0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/thermodynamics/test_hessianJob.py
+++ b/tests/thermodynamics/test_hessianJob.py
@@ -25,6 +25,8 @@ class TestHessianJob(unittest.TestCase):
         )
         cls.job.set_reference_structure(structure)
         cls.job.structure.positions[0,0] = 0.1
+        cls.job.structure.positions[0,1] -= 0.1
+        cls.job.structure.center_coordinates_in_unit_cell()
         cls.job.set_force_constants(1)
         cls.job.run()
 
@@ -36,6 +38,7 @@ class TestHessianJob(unittest.TestCase):
 
     def test_forces(self):
         self.assertAlmostEqual(self.job.output.forces[0,0,0], -0.1)
+        self.assertAlmostEqual(self.job.output.forces[0,0,1], 0.1)
 
 
 if __name__ == "__main__":

--- a/tests/thermodynamics/test_hessianJob.py
+++ b/tests/thermodynamics/test_hessianJob.py
@@ -16,6 +16,7 @@ class TestHessianJob(unittest.TestCase):
         cls.project = Project(
             os.path.join(cls.file_location, "hessian_class")
         )
+        cls.project.remove_jobs_silently(recursive=True)
         cls.job = cls.project.create_job(
             "HessianJob", "job_test_hessian"
         )

--- a/tests/thermodynamics/test_hessianJob.py
+++ b/tests/thermodynamics/test_hessianJob.py
@@ -24,10 +24,12 @@ class TestHessianJob(unittest.TestCase):
             positions=[[0, 0, 0], [1, 1, 1]], elements=["Fe", "Fe"], cell=2 * np.eye(3)
         )
         cls.job.set_reference_structure(structure)
+        cls.job.structure.apply_strain(0.01)
         cls.job.structure.positions[0,0] = 0.1
         cls.job.structure.positions[0,1] -= 0.1
         cls.job.structure.center_coordinates_in_unit_cell()
-        cls.job.set_force_constants(1)
+        cls.job.set_force_constants(force_constants=1)
+        cls.job.set_elastic_moduli(bulk_modulus=1, shear_modulus=1)
         cls.job.run()
 
     @classmethod
@@ -39,6 +41,7 @@ class TestHessianJob(unittest.TestCase):
     def test_forces(self):
         self.assertAlmostEqual(self.job.output.forces[0,0,0], -0.1)
         self.assertAlmostEqual(self.job.output.forces[0,0,1], 0.1)
+        self.assertAlmostEqual(self.job.output.pressures[0,0,0], -0.03)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following @jan-janssen 's comment, replace the core part of `EinstenExampleJob` by `HessianJob`