### PR TITLE
Get global shells

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -3700,7 +3700,7 @@ class Neighbors:
             decimals (int): decimals in np.round for rounding up distances
 
         Returns:
-            shells (ndarray): shell indices (cf. shells)
+            shells (numpy.ndarray): shell indices (cf. shells)
         """
         if self.distances is None:
             raise ValueError('neighbors not set')

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -3691,11 +3691,22 @@ class Neighbors:
             raise TypeError("Only lists and np.arrays are supported.")
 
     def get_global_shells(self, decimals=5):
+        """
+        Set shell indices based on all distances available in the system instead of
+        setting them according to the local distances (in contrast to shells defined
+        as an attribute in this class)
+
+        Args:
+            decimals (int): decimals in np.round for rounding up distances
+
+        Returns:
+            shells (ndarray): shell indices (cf. shells)
+        """
         if self.distances is None:
             raise ValueError('neighbors not set')
         distances = np.unique(np.round(a=self.distances, decimals=decimals))
         shells = self.distances[:,:,np.newaxis]-distances[np.newaxis,np.newaxis,:]
-        shells = np.absolute(shells).argmin(axis=-1)
+        shells = np.absolute(shells).argmin(axis=-1)+1
         return shells
 
 class CrystalStructure(object):

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -3690,6 +3690,13 @@ class Neighbors:
         else:
             raise TypeError("Only lists and np.arrays are supported.")
 
+    def get_global_shells(self, decimals=5):
+        if self.distances is None:
+            raise ValueError('neighbors not set')
+        distances = np.unique(np.round(a=self.distances, decimals=decimals))
+        shells = self.distances[:,:,np.newaxis]-distances[np.newaxis,np.newaxis,:]
+        shells = np.absolute(shells).argmin(axis=-1)
+        return shells
 
 class CrystalStructure(object):
     def __new__(cls, *args, **kwargs):

--- a/pyiron/lammps/structure.py
+++ b/pyiron/lammps/structure.py
@@ -431,12 +431,12 @@ class LammpsStructure(GenericParameters):
                     for i, v in enumerate(val["element_list"]):
                         el_2_list = self._structure.select_index(v)
                         cutoff_dist = val["cutoff_list"][i]
-                        for j, ind in enumerate(neighbors.indices[el_1_list]):
+                        for j, ind in enumerate(np.array(neighbors.indices[el_1_list])):
                             # Only chose those indices within the cutoff distance and which belong
                             # to the species defined in the element_list
                             # i is the index of each bond type, and j is the element index
                             id_el = el_1_list[j]
-                            bool_1 = neighbors.distances[id_el] <= cutoff_dist
+                            bool_1 = np.array(neighbors.distances[id_el]) <= cutoff_dist
                             act_ind = ind[bool_1]
                             bool_2 = np.in1d(act_ind, el_2_list)
                             final_ind = act_ind[bool_2]

--- a/pyiron/lammps/structure.py
+++ b/pyiron/lammps/structure.py
@@ -431,12 +431,12 @@ class LammpsStructure(GenericParameters):
                     for i, v in enumerate(val["element_list"]):
                         el_2_list = self._structure.select_index(v)
                         cutoff_dist = val["cutoff_list"][i]
-                        for j, ind in enumerate(np.array(neighbors.indices[el_1_list])):
+                        for j, ind in enumerate(neighbors.indices[el_1_list]):
                             # Only chose those indices within the cutoff distance and which belong
                             # to the species defined in the element_list
                             # i is the index of each bond type, and j is the element index
                             id_el = el_1_list[j]
-                            bool_1 = np.array(neighbors.distances[id_el]) <= cutoff_dist
+                            bool_1 = neighbors.distances[id_el] <= cutoff_dist
                             act_ind = ind[bool_1]
                             bool_2 = np.in1d(act_ind, el_2_list)
                             final_ind = act_ind[bool_2]

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -739,8 +739,12 @@ class TestAtoms(unittest.TestCase):
             neigh = basis.get_neighbors(cutoff=10)
             self.assertEqual(len(w), 1)
             self.assertIsInstance(w[-1].message, DeprecationWarning)
-        # print nbr_dict.distances
-        # print [set(s) for s in nbr_dict.shells]
+        structure = CrystalStructure(elements='Fe', lattice_constant=2.83, bravais='bcc').repeat(2)
+        neigh = structure.get_neighbors()
+        self.assertTrue(np.all(neigh.shells==neigh.get_global_shells()))
+        structure += Atoms(elements='C', positions=[[0, 0, 0.5*2.83]])
+        neigh = structure.get_neighbors()
+        self.assertFalse(np.all(neigh.shells==neigh.get_global_shells()))
 
     def test_center_coordinates(self):
         cell = 2.2 * np.identity(3)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -741,10 +741,10 @@ class TestAtoms(unittest.TestCase):
             self.assertIsInstance(w[-1].message, DeprecationWarning)
         structure = CrystalStructure(elements='Fe', lattice_constant=2.83, bravais='bcc').repeat(2)
         neigh = structure.get_neighbors()
-        self.assertTrue(np.all(neigh.shells==neigh.get_global_shells()))
+        self.assertTrue(np.array_equal(neigh.shells, neigh.get_global_shells()))
         structure += Atoms(elements='C', positions=[[0, 0, 0.5*2.83]])
         neigh = structure.get_neighbors()
-        self.assertFalse(np.all(neigh.shells==neigh.get_global_shells()))
+        self.assertFalse(np.array_equal(neigh.shells, neigh.get_global_shells()))
 
     def test_center_coordinates(self):
         cell = 2.2 * np.identity(3)


### PR DESCRIPTION
In the unit test I already included a Paradebeispiel (perfect example) for what `neigh.get_global_shells()` is useful for - For example, when a system is a perfect crystal with let's say one solute atom, the shell index 1 (and any other index) is not the same everywhere when we use `neigh.shells`. With `neigh.get_global_shells()`, you can be sure that wherever the same index can be found, the distance value is the same.