### PR TITLE
Extend get neighbors

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1858,8 +1858,6 @@ class Atoms(ASEAtoms):
             raise ValueError(
                 "Increase max_num_neighbors! " + str(max_nbr) + " " + str(num_neighbors)
             )
-        self.min_nbr_number = min_nbr
-        self.max_nbr_number = max_nbr
         neighbor_obj.distances = neighbor_distance
         neighbor_obj.vecs = neighbor_distance_vec
         neighbor_obj.indices = neighbor_indices

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1951,10 +1951,9 @@ class Atoms(ASEAtoms):
 
 
     def get_shell_matrix(
-        self, shell=None, id_list=None, restraint_matrix=None, num_neighbors=100, tolerance=2
+        self, id_list=None, chemical_symbols=None, num_neighbors=100, tolerance=2,
+        cluster_by_distances=False, cluster_by_vecs=False
     ):
-        if shell is not None and shell<=0:
-            raise ValueError("Parameter 'shell' must be an integer greater than 0")
         neigh_list = self.get_neighbors(
             num_neighbors=num_neighbors, id_list=id_list, tolerance=tolerance
         )
@@ -1962,7 +1961,11 @@ class Atoms(ASEAtoms):
             + 'It is not guaranteed to be in service in vers. 1.0.'
             + 'Use neigh.get_shell_matrix() instead (after calling neigh = structure.get_neighbors()).',
             DeprecationWarning)
-        return neigh_list.get_shell_matrix(shell_numbers=shell, restraint_matrix=restraint_matrix)
+        return neigh_list.get_shell_matrix(
+            chemical_symbols=chemical_symbols,
+            cluster_by_distances=cluster_by_distances,
+            cluster_by_vecs=cluster_by_vecs
+        )
     get_shell_matrix.__doc__ = Neighbors.get_shell_matrix.__doc__
 
     def occupy_lattice(self, **qwargs):

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1951,7 +1951,7 @@ class Atoms(ASEAtoms):
 
 
     def get_shell_matrix(
-        self, id_list=None, chemical_symbols=None, num_neighbors=100, tolerance=2,
+        self, id_list=None, chemical_pair=None, num_neighbors=100, tolerance=2,
         cluster_by_distances=False, cluster_by_vecs=False
     ):
         neigh_list = self.get_neighbors(
@@ -1962,7 +1962,7 @@ class Atoms(ASEAtoms):
             + 'Use neigh.get_shell_matrix() instead (after calling neigh = structure.get_neighbors()).',
             DeprecationWarning)
         return neigh_list.get_shell_matrix(
-            chemical_symbols=chemical_symbols,
+            chemical_pair=chemical_pair,
             cluster_by_distances=cluster_by_distances,
             cluster_by_vecs=cluster_by_vecs
         )

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -89,18 +89,18 @@ class Neighbors(object):
         """
         if sort_by_distances:
             if self._cluster_dist is None:
-                self.sort_by_distances()
+                self.sort_shells_by_distances(use_vecs=sort_by_vecs)
             shells = [np.unique(np.round(dist, decimals=self._tolerance), return_inverse=True)[1]+1
-                         for dist in self._cluster_dist.cluster_centers_.flatten()
+                         for dist in self._cluster_dist.cluster_centers_[self._cluster_dist.labels_].flatten()
                      ]
             if isinstance(self.distances, np.ndarray):
                 return np.array(shells)
             return shells
         if sort_by_vecs:
             if self._cluster_vecs is None:
-                self.sort_by_vecs()
+                self.sort_shells_by_vecs()
             shells = [np.unique(np.round(dist, decimals=self._tolerance), return_inverse=True)[1]+1
-                         for dist in np.linalg.norm(self._cluster_vecs.cluster_centers_, axis=-1)
+                         for dist in np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1)
                      ]
             if isinstance(self.distances, np.ndarray):
                 return np.array(shells)
@@ -132,12 +132,12 @@ class Neighbors(object):
         distances = self.distances
         if sort_by_distances:
             if self._cluster_dist is None:
-                self.sort_by_distances()
-            distances = self._cluster_dist.cluster_centers_.reshape(self.distances.shape)
+                self.sort_shells_by_distances(use_vecs=sort_by_vecs)
+            distances = self._cluster_dist.cluster_centers_[self._cluster_dist.labels_].reshape(self.distances.shape)
         elif sort_by_vecs:
             if self._cluster_vecs is None:
-                self.sort_by_vecs()
-            distances = np.linalg.norm(self._cluster_vecs.cluster_centers_, axis=-1).reshape(self.distances.shape)
+                self.sort_shells_by_vecs()
+            distances = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1).reshape(self.distances.shape)
         dist_lst = np.unique(np.round(a=distances, decimals=decimals))
         shells = distances[:,:,np.newaxis]-dist_lst[np.newaxis,np.newaxis,:]
         shells = np.absolute(shells).argmin(axis=-1)+1
@@ -225,7 +225,7 @@ class Neighbors(object):
         if use_vecs:
             if self._cluster_vecs is None or force_rerun:
                 self.sort_shells_by_vectors()
-            dr = np.linalg.norm(self._cluster_vecs.cluster_centers_, axis=-1)
+            dr = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1)
         self._cluster_dist = MeanShift(bandwidth=bandwidth).fit(dr.reshape(-1, 1))
 
 

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -78,7 +78,7 @@ class Neighbors(object):
             raise AssertionError()
         return shell_dict
 
-    def get_local_shells(self, tolerance=5, cluster_by_distances=False, cluster_by_vecs=False):
+    def get_local_shells(self, tolerance=2, cluster_by_distances=False, cluster_by_vecs=False):
         """
         Set shell indices based on distances available to each atom
 
@@ -112,7 +112,7 @@ class Neighbors(object):
                 self._shells = np.array(self._shells)
         return self._shells
 
-    def get_global_shells(self, tolerance=5, cluster_by_distances=False, cluster_by_vecs=False):
+    def get_global_shells(self, tolerance=2, cluster_by_distances=False, cluster_by_vecs=False):
         """
         Set shell indices based on all distances available in the system instead of
         setting them according to the local distances (in contrast to shells defined

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -164,7 +164,8 @@ class Neighbors(object):
         self, chemical_pair=None, cluster_by_distances=False, cluster_by_vecs=False
     ):
         """
-        Shell matrices for pairwise interaction.
+        Shell matrices for pairwise interaction. Note: The matrices are always symmetric, meaning if you
+        use them as bilinear operators, you have to divide the results by 2.
 
         Args:
             chemical_pair (list): pair of chemical symbols (e.g. ['Fe', 'Ni'])
@@ -180,7 +181,7 @@ class Neighbors(object):
             magmoms = 2*np.random.random((len(structure)), 3)-1 # Random magnetic moments between -1 and 1
             neigh = structure.get_neighbors(num_neighbors=8) # Iron first shell
             shell_matrices = neigh.get_shell_matrix()
-            print('Energy =', J*magmoms.dot(shell_matrices[0].dot(matmoms)))
+            print('Energy =', 0.5*J*magmoms.dot(shell_matrices[0].dot(matmoms)))
         """
 
         pairs = np.stack((self.indices,

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -165,10 +165,13 @@ class Neighbors(object):
         shell_matrix = []
         for ind in np.arange(shell_max):
             indices = pairs[ind==pairs[:,-1]]
-            ind_tmp = np.unique(indices[:,:-1], axis=0, return_counts=True)
-            shell_matrix.append(coo_matrix((ind_tmp[1], (ind_tmp[0][:,0], ind_tmp[0][:,1])),
-                shape=(len(self._ref_structure), len(self._ref_structure))
-            ))
+            if len(indices)>0:
+                ind_tmp = np.unique(indices[:,:-1], axis=0, return_counts=True)
+                shell_matrix.append(coo_matrix((ind_tmp[1], (ind_tmp[0][:,0], ind_tmp[0][:,1])),
+                    shape=(len(self._ref_structure), len(self._ref_structure))
+                ))
+            else:
+                shell_matrix.append(coo_matrix((len(self._ref_structure), len(self._ref_structure))))
         return shell_matrix
 
     def find_neighbors_by_vector(self, vector, deviation=False):

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -113,7 +113,7 @@ class Neighbors(object):
                 self._shells.append(np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1)
             if isinstance(self.distances, np.ndarray):
                 self._shells = np.array(self._shells)
-            return self._shells
+        return self._shells
 
     def get_global_shells(self, tolerance=5, sort_by_distances=False, sort_by_vecs=False):
         """

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -77,7 +77,7 @@ class Neighbors(object):
             raise AssertionError()
         return shell_dict
 
-    def get_local_shells(self, tolerance=5, sort_by_distances=False, sort_by_vecs=False):
+    def get_local_shells(self, tolerance=5, cluster_by_distances=False, cluster_by_vecs=False):
         """
         Set shell indices based on distances available to each atom
 
@@ -87,16 +87,16 @@ class Neighbors(object):
         Returns:
             shells (numpy.ndarray): shell indices
         """
-        if sort_by_distances:
+        if cluster_by_distances:
             if self._cluster_dist is None:
-                self.sort_shells_by_distances(use_vecs=sort_by_vecs)
+                self.cluster_by_distances(use_vecs=cluster_by_vecs)
             shells = [np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1
                          for dist in self._cluster_dist.cluster_centers_[self._cluster_dist.labels_].flatten()
                      ]
             if isinstance(self.distances, np.ndarray):
                 return np.array(shells)
             return shells
-        if sort_by_vecs:
+        if cluster_by_vecs:
             if self._cluster_vecs is None:
                 self.sort_shells_by_vecs()
             shells = [np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1
@@ -115,7 +115,7 @@ class Neighbors(object):
                 self._shells = np.array(self._shells)
         return self._shells
 
-    def get_global_shells(self, tolerance=5, sort_by_distances=False, sort_by_vecs=False):
+    def get_global_shells(self, tolerance=5, cluster_by_distances=False, cluster_by_vecs=False):
         """
         Set shell indices based on all distances available in the system instead of
         setting them according to the local distances (in contrast to shells defined
@@ -130,11 +130,11 @@ class Neighbors(object):
         if self.distances is None:
             raise ValueError('neighbors not set')
         distances = self.distances
-        if sort_by_distances:
+        if cluster_by_distances:
             if self._cluster_dist is None:
-                self.sort_shells_by_distances(use_vecs=sort_by_vecs)
+                self.cluster_by_distances(use_vecs=cluster_by_vecs)
             distances = self._cluster_dist.cluster_centers_[self._cluster_dist.labels_].reshape(self.distances.shape)
-        elif sort_by_vecs:
+        elif cluster_by_vecs:
             if self._cluster_vecs is None:
                 self.sort_shells_by_vecs()
             distances = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1).reshape(self.distances.shape)
@@ -211,21 +211,25 @@ class Neighbors(object):
             return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)], np.min(dist, axis=-1)
         return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)]
 
-    def sort_shells_by_vectors(self, bandwidth=None):
+    def cluster_by_vecs(self, bandwidth=None):
         if bandwidth is None:
             bandwidth = 0.1*np.min(self.distances)
         dr = self.vecs.copy().reshape(-1, 3)
         self._cluster_vecs = MeanShift(bandwidth=bandwidth).fit(dr)
-#         self.cluster_3D = GaussianMixture(covariance_type='tied').fit(dr)
 
-    def sort_shells_by_distances(self, bandwidth=None, use_vecs=False, force_rerun=False):
+    def cluster_by_distances(self, bandwidth=None, use_vecs=False, force_rerun=False):
         if bandwidth is None:
             bandwidth = 0.05*np.min(self.distances)
         dr = self.distances
         if use_vecs:
             if self._cluster_vecs is None or force_rerun:
-                self.sort_shells_by_vectors()
+                self.cluster_by_vecs()
             dr = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1)
         self._cluster_dist = MeanShift(bandwidth=bandwidth).fit(dr.reshape(-1, 1))
 
+    def reset_clusters(self, vecs=True, distances=True):
+        if vecs:
+            self._cluster_vecs = None
+        if distances:
+            self._cluster_distances = None
 

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -211,7 +211,7 @@ class Neighbors(object):
             max_iter (int): Number of maximum iterations (cf. sklearn.cluster.MeanShift)
         """
         if bandwidth is None:
-            bandwidth = 0.1*np.min(self.distances)
+            bandwidth = 0.2*np.min(self.distances)
         dr = self.vecs.copy().reshape(-1, 3)
         self._cluster_vecs = MeanShift(bandwidth=bandwidth, n_jobs=n_jobs, max_iter=max_iter).fit(dr)
         self._cluster_vecs.labels_ = self._cluster_vecs.labels_.reshape(self.indices.shape)

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -141,12 +141,12 @@ class Neighbors(object):
         return shells
 
     def get_shell_matrix(
-        self, chemical_symbols=None, cluster_by_distances=False, cluster_by_vecs=False
+        self, chemical_pair=None, cluster_by_distances=False, cluster_by_vecs=False
     ):
         """
 
         Args:
-            chemical_symbols (list): pair of chemical symbols
+            chemical_pair (list): pair of chemical symbols
 
         Returns:
             sparse matrix for different shells
@@ -159,9 +159,9 @@ class Neighbors(object):
             axis=-1
         ).reshape(-1, 3)
         shell_max = np.max(pairs[:,-1])+1
-        if chemical_symbols is not None:
+        if chemical_pair is not None:
             c = self._ref_structure.get_chemical_symbols()
-            pairs = pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]
+            pairs = pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_pair), axis=-1)]
         shell_matrix = []
         for ind in np.arange(shell_max):
             indices = pairs[ind==pairs[:,-1]]

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -162,11 +162,12 @@ class Neighbors(object):
             self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs)-1),
             axis=-1
         ).reshape(-1, 3)
+        shell_max = np.max(pairs[:,-1])
         if chemical_symbols is not None:
             c = self._ref_structure.get_chemical_symbols()
-            pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]
+            pairs = pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]
         shell_matrix = []
-        for ind in np.arange(np.max(pairs[:,-1])):
+        for ind in np.arange(shell_max):
             indices = pairs[ind==pairs[:,-1]]
             ind_tmp = np.unique(indices[:,:-1], axis=0, return_counts=True)
             shell_matrix.append(coo_matrix((ind_tmp[1], (ind_tmp[0][:,0], ind_tmp[0][:,1])),

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -159,7 +159,7 @@ class Neighbors(object):
 
         pairs = np.stack((self.indices,
             np.ones_like(self.indices)*np.arange(len(self.indices))[:,np.newaxis],
-            self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs)),
+            self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs))-1,
             axis=-1
         ).reshape(-1, 3)
         if chemical_symbols is not None:

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -3,6 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import numpy as np
+from sklearn.cluster import MeanShift
 from pyiron_base import Settings
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal"
@@ -225,6 +226,6 @@ class Neighbors(object):
             if self._cluster_vecs is None or force_rerun:
                 self.sort_shells_by_vectors()
             dr = np.linalg.norm(self._cluster_vecs.cluster_centers_, axis=-1)
-        self._cluster_dist = MeanShift(bandwidth=self.sigma_norm).fit(dr.reshape(-1, 1))
+        self._cluster_dist = MeanShift(bandwidth=bandwidth).fit(dr.reshape(-1, 1))
 
 

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -90,7 +90,7 @@ class Neighbors(object):
         if sort_by_distances:
             if self._cluster_dist is None:
                 self.sort_shells_by_distances(use_vecs=sort_by_vecs)
-            shells = [np.unique(np.round(dist, decimals=self._tolerance), return_inverse=True)[1]+1
+            shells = [np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1
                          for dist in self._cluster_dist.cluster_centers_[self._cluster_dist.labels_].flatten()
                      ]
             if isinstance(self.distances, np.ndarray):
@@ -99,7 +99,7 @@ class Neighbors(object):
         if sort_by_vecs:
             if self._cluster_vecs is None:
                 self.sort_shells_by_vecs()
-            shells = [np.unique(np.round(dist, decimals=self._tolerance), return_inverse=True)[1]+1
+            shells = [np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1
                          for dist in np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1)
                      ]
             if isinstance(self.distances, np.ndarray):
@@ -110,7 +110,7 @@ class Neighbors(object):
                 return None
             self._shells = []
             for dist in self.distances:
-                self._shells.append(np.unique(np.round(dist, decimals=self._tolerance), return_inverse=True)[1]+1)
+                self._shells.append(np.unique(np.round(dist, decimals=tolerance), return_inverse=True)[1]+1)
             if isinstance(self.distances, np.ndarray):
                 self._shells = np.array(self._shells)
             return self._shells
@@ -138,7 +138,7 @@ class Neighbors(object):
             if self._cluster_vecs is None:
                 self.sort_shells_by_vecs()
             distances = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1).reshape(self.distances.shape)
-        dist_lst = np.unique(np.round(a=distances, decimals=decimals))
+        dist_lst = np.unique(np.round(a=distances, decimals=tolerance))
         shells = distances[:,:,np.newaxis]-dist_lst[np.newaxis,np.newaxis,:]
         shells = np.absolute(shells).argmin(axis=-1)+1
         return shells

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -164,7 +164,7 @@ class Neighbors(object):
         ).reshape(-1, 3)
         if chemical_symbols is not None:
             c = self._ref_structure.get_chemical_symbols()
-            pairs[np.all(np.sort(chemical_symbols[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]
+            pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]
         shell_matrix = []
         for ind in np.arange(np.max(pairs[:,-1])):
             indices = pairs[ind==pairs[:,-1]]

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -34,6 +34,9 @@ class Neighbors(object):
 
     @property
     def shells(self):
+        """
+            Returns the cell numbers of each atom according to the distances
+        """
         if self._shells is None:
             if self.distances is None:
                 return None
@@ -43,6 +46,19 @@ class Neighbors(object):
             if isinstance(self.distances, np.ndarray):
                 self._shells = np.array(self._shells)
             return self._shells
+
+    def update_vectors(self):
+        """
+            Update vecs and distances with the same indices
+        """
+        if np.max(np.absolute(self.vecs)) > 0.49*np.min(np.linalg.norm(self._ref_structure.cell, axis=-1)):
+            raise AssertionError('Largest distance value is larger than half the box -> rerun get_neighbors')
+        myself = np.ones_like(self.indices)*np.arange(len(self.indices))[:, np.newaxis]
+        vecs = self._ref_structure.get_distances(
+            myself.flatten(), self.indices.flatten(), mic=np.all(self._ref_structure.pbc), vector=True
+        )
+        self.vecs = vecs.reshape(self.vecs.shape)
+        self.distances = np.linalg.norm(self.vecs, axis=-1)
 
     def get_shell_dict(self, max_shell=2):
         """

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -7,13 +7,13 @@ from sklearn.cluster import MeanShift
 from scipy.sparse import coo_matrix
 from pyiron_base import Settings
 
-__author__ = "Joerg Neugebauer, Sudarsan Surendralal"
+__author__ = "Joerg Neugebauer, Sam Waseda"
 __copyright__ = (
     "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
     "Computational Materials Design (CM) Department"
 )
 __version__ = "1.0"
-__maintainer__ = "Osamu Waseda"
+__maintainer__ = "Sam Waseda"
 __email__ = "waseda@mpie.de"
 __status__ = "production"
 __date__ = "Sep 1, 2017"

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -159,7 +159,7 @@ class Neighbors(object):
 
         pairs = np.stack((self.indices,
             np.ones_like(self.indices)*np.arange(len(self.indices))[:,np.newaxis],
-            self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs))-1,
+            self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs)-1),
             axis=-1
         ).reshape(-1, 3)
         if chemical_symbols is not None:

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -162,7 +162,7 @@ class Neighbors(object):
             self.get_global_shells(cluster_by_distances=cluster_by_distances, cluster_by_vecs=cluster_by_vecs)-1),
             axis=-1
         ).reshape(-1, 3)
-        shell_max = np.max(pairs[:,-1])
+        shell_max = np.max(pairs[:,-1])+1
         if chemical_symbols is not None:
             c = self._ref_structure.get_chemical_symbols()
             pairs = pairs[np.all(np.sort(c[pairs[:,:2]], axis=-1)==np.sort(chemical_symbols), axis=-1)]

--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -211,13 +211,13 @@ class Neighbors(object):
             return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)], np.min(dist, axis=-1)
         return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)]
 
-    def cluster_by_vecs(self, bandwidth=None):
+    def cluster_by_vecs(self, bandwidth=None, n_jobs=None, max_iter=300):
         if bandwidth is None:
             bandwidth = 0.1*np.min(self.distances)
         dr = self.vecs.copy().reshape(-1, 3)
-        self._cluster_vecs = MeanShift(bandwidth=bandwidth).fit(dr)
+        self._cluster_vecs = MeanShift(bandwidth=bandwidth, n_jobs=n_jobs, max_iter=max_iter).fit(dr)
 
-    def cluster_by_distances(self, bandwidth=None, use_vecs=False, force_rerun=False):
+    def cluster_by_distances(self, bandwidth=None, use_vecs=False, force_rerun=False, n_jobs=None, max_iter=300):
         if bandwidth is None:
             bandwidth = 0.05*np.min(self.distances)
         dr = self.distances
@@ -225,7 +225,7 @@ class Neighbors(object):
             if self._cluster_vecs is None or force_rerun:
                 self.cluster_by_vecs()
             dr = np.linalg.norm(self._cluster_vecs.cluster_centers_[self._cluster_vecs.labels_], axis=-1)
-        self._cluster_dist = MeanShift(bandwidth=bandwidth).fit(dr.reshape(-1, 1))
+        self._cluster_dist = MeanShift(bandwidth=bandwidth, n_jobs=n_jobs, max_iter=max_iter).fit(dr.reshape(-1, 1))
 
     def reset_clusters(self, vecs=True, distances=True):
         if vecs:

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -721,6 +721,10 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(neigh.distances[0], 0.1)
 
     def test_get_neighbors_update_vectors(self):
+        structure = CrystalStructure(elements='Fe', lattice_constants=1, bravais_basis='bcc', pbc=True)
+        neigh = structure.get_neighbors(num_neighbors=8)
+        with self.assertRaises(AssertionError):
+            neigh.update_vectors()
         structure = CrystalStructure(elements='Fe', lattice_constants=1, bravais_basis='bcc', pbc=True).repeat(2)
         neigh = structure.get_neighbors(num_neighbors=8)
         self.assertAlmostEqual(np.min(neigh.distances), np.sqrt(3)/2)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -749,12 +749,6 @@ class TestAtoms(unittest.TestCase):
         with self.assertRaises(ValueError):
             basis.get_neighbors(cutoff_radius=10)
         basis.get_neighbors_by_distance(cutoff_radius=10)
-        structure = CrystalStructure(elements='Fe', lattice_constants=2.83, bravais_basis='bcc').repeat(2)
-        neigh = structure.get_neighbors()
-        self.assertTrue(np.array_equal(neigh.shells, neigh.get_global_shells()))
-        structure += Atoms(elements='C', positions=[[0, 0, 0.5*2.83]])
-        neigh = structure.get_neighbors()
-        self.assertFalse(np.array_equal(neigh.shells, neigh.get_global_shells()))
 
     def test_center_coordinates(self):
         cell = 2.2 * np.identity(3)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -829,15 +829,6 @@ class TestAtoms(unittest.TestCase):
         Al_sc.set_repeat([3, 3, 3])
         self.assertEqual(np.round(Al_sc.get_shells()[2], 6), 2.2)
 
-    def test_get_shell_matrix(self):
-        basis = Atoms(
-            "FeFe", scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=np.identity(3)
-        )
-        output = basis.get_shell_matrix(shell=1, restraint_matrix=["Fe", "Fe"])
-        self.assertIsInstance(output, np.ndarray)
-        self.assertEqual(np.sum(output), 16)
-        self.assertTrue(np.all(np.dot(output, output) == np.identity(2) * 64))
-
     def test_get_distances_array(self):
         basis = Atoms("FeFe", positions=[3*[0], 3*[0.9]], cell=np.identity(3), pbc=True)
         self.assertAlmostEqual(basis.get_distances_array(mic=False)[0, 1], 0.9*np.sqrt(3))

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -720,6 +720,14 @@ class TestAtoms(unittest.TestCase):
         neigh = basis.get_neighborhood([0, 0, 0.1])
         self.assertEqual(neigh.distances[0], 0.1)
 
+    def test_get_neighbors_update_vectors(self):
+        structure = CrystalStructure(elements='Fe', lattice_constants=1, bravais_basis='bcc', pbc=True).repeat(2)
+        neigh = structure.get_neighbors(num_neighbors=8)
+        self.assertAlmostEqual(np.min(neigh.distances), np.sqrt(3)/2)
+        structure.positions[0] += 0.01
+        neigh.update_vectors()
+        self.assertAlmostEqual(np.min(neigh.distances), np.sqrt(3)*0.49)
+
     def test_get_neighbors(self):
         cell = 2.2 * np.identity(3)
         NaCl = Atoms("NaCl", scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell)
@@ -737,7 +745,7 @@ class TestAtoms(unittest.TestCase):
         with self.assertRaises(ValueError):
             basis.get_neighbors(cutoff_radius=10)
         basis.get_neighbors_by_distance(cutoff_radius=10)
-        structure = CrystalStructure(elements='Fe', lattice_constant=2.83, bravais='bcc').repeat(2)
+        structure = CrystalStructure(elements='Fe', lattice_constants=2.83, bravais_basis='bcc').repeat(2)
         neigh = structure.get_neighbors()
         self.assertTrue(np.array_equal(neigh.shells, neigh.get_global_shells()))
         structure += Atoms(elements='C', positions=[[0, 0, 0.5*2.83]])
@@ -1020,11 +1028,11 @@ class TestAtoms(unittest.TestCase):
         self.assertTrue(np.array_equal(self.CO2.positions, new_array))
 
     def test_get_positions(self):
-        basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)
+        basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constants=4.2)
         self.assertTrue(np.array_equal(basis_Mg.positions, basis_Mg.get_positions()))
 
     def test_get_scaled_positions(self):
-        basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constant=4.2)
+        basis_Mg = CrystalStructure("Mg", bravais_basis="fcc", lattice_constants=4.2)
         basis_Mg.set_cell(basis_Mg.cell+0.1 * np.random.random((3, 3)))
         basis_Mg = basis_Mg.center_coordinates_in_unit_cell()
         self.assertTrue(

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -750,6 +750,12 @@ class TestAtoms(unittest.TestCase):
             basis.get_neighbors(cutoff_radius=10)
         basis.get_neighbors_by_distance(cutoff_radius=10)
 
+    def test_get_shell_matrix(self):
+        structure = CrystalStructure(elements='Fe', lattice_constants=2.83, bravais_basis='bcc')
+        shell_mat_atoms = structure.get_shell_matrix(num_neighbors=8)
+        neigh = structure.get_neighbors(num_neighbors=8)
+        self.assertEqual(shell_mat_atoms[0].sum(), neigh.get_shell_matrix()[0].sum())
+
     def test_center_coordinates(self):
         cell = 2.2 * np.identity(3)
         NaCl = Atoms("NaCl", scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)], cell=cell)

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -46,11 +46,12 @@ class TestAtoms(unittest.TestCase):
 
     def test_get_shell_matrix(self):
         structure = CrystalStructure(elements='Fe', lattice_constants=2.83, bravais_basis='bcc').repeat(2)
+        structure[0] = 'Ni'
         neigh = structure.get_neighbors(num_neighbors=8)
         mat = neigh.get_shell_matrix()
         self.assertEqual(mat[0].sum(), 8*len(structure))
-        mat = neigh.get_shell_matrix(chemical_symbols=['Ni', 'Ni'])
-        self.assertEqual(mat[0].sum(), 0)
+        mat = neigh.get_shell_matrix(chemical_symbols=['Fe', 'Ni'])
+        self.assertEqual(mat[0].sum(), 16)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -50,9 +50,9 @@ class TestAtoms(unittest.TestCase):
         neigh = structure.get_neighbors(num_neighbors=8)
         mat = neigh.get_shell_matrix()
         self.assertEqual(mat[0].sum(), 8*len(structure))
-        mat = neigh.get_shell_matrix(chemical_symbols=['Fe', 'Ni'])
+        mat = neigh.get_shell_matrix(chemical_pair=['Fe', 'Ni'])
         self.assertEqual(mat[0].sum(), 16)
-        mat = neigh.get_shell_matrix(chemical_symbols=['Ni', 'Ni'])
+        mat = neigh.get_shell_matrix(chemical_pair=['Ni', 'Ni'])
         self.assertEqual(mat[0].sum(), 0)
 
 if __name__ == "__main__":

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -1,0 +1,24 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import unittest
+import numpy as np
+import os
+import warnings
+from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
+
+
+class TestAtoms(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -18,7 +18,41 @@ class TestAtoms(unittest.TestCase):
     def setUpClass(cls):
         pass
 
+    def test_get_global_shells(self):
+        structure = CrystalStructure(elements='Al', lattice_constants=4, bravais_basis='fcc').repeat(2)
+        neigh = structure.get_neighbors()
+        self.assertTrue(np.array_equal(neigh.shells, neigh.get_global_shells()))
+        structure += Atoms(elements='C', positions=[[0, 0, 0.5*4]])
+        neigh = structure.get_neighbors()
+        self.assertFalse(np.array_equal(neigh.shells, neigh.get_global_shells()))
+        structure = CrystalStructure(elements='Al', lattice_constants=4, bravais_basis='fcc').repeat(2)
+        neigh = structure.get_neighbors()
+        shells = neigh.get_global_shells()
+        structure.positions += 0.01*(np.random.random((len(structure), 3))-0.5)
+        neigh = structure.get_neighbors()
+        self.assertTrue(np.array_equal(shells, neigh.get_global_shells(cluster_by_vecs=True, cluster_by_distances=True)))
+        neigh.reset_clusters()
+        self.assertTrue(np.array_equal(shells, neigh.get_global_shells(cluster_by_vecs=True)))
+        self.assertFalse(np.array_equal(shells, neigh.get_global_shells()))
 
+    def test_get_local_shells(self):
+        structure = CrystalStructure(elements='Al', lattice_constants=4, bravais_basis='fcc').repeat(2)
+        neigh = structure.get_neighbors()
+        shells = neigh.get_local_shells()
+        structure.positions += 0.01*(np.random.random((len(structure), 3))-0.5)
+        neigh = structure.get_neighbors()
+        self.assertTrue(np.array_equal(shells, neigh.get_local_shells(cluster_by_vecs=True, cluster_by_distances=True)))
+        neigh.reset_clusters()
+        self.assertTrue(np.array_equal(shells, neigh.get_local_shells(cluster_by_vecs=True)))
+        self.assertFalse(np.array_equal(shells, neigh.get_local_shells()))
+
+    def test_get_shell_matrix(self):
+        structure = CrystalStructure(elements='Fe', lattice_constants=2.83, bravais_basis='bcc').repeat(2)
+        neigh = structure.get_neighbors(num_neighbors=8)
+        mat = neigh.get_shell_matrix()
+        self.assertEqual(mat[0].sum(), 8*len(structure))
+        mat = neigh.get_shell_matrix(chemical_symbols=['Ni', 'Ni'])
+        self.assertEqual(mat[0].sum(), 0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -4,8 +4,6 @@
 
 import unittest
 import numpy as np
-import os
-import warnings
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
 
 

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -52,6 +52,8 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(mat[0].sum(), 8*len(structure))
         mat = neigh.get_shell_matrix(chemical_symbols=['Fe', 'Ni'])
         self.assertEqual(mat[0].sum(), 16)
+        mat = neigh.get_shell_matrix(chemical_symbols=['Ni', 'Ni'])
+        self.assertEqual(mat[0].sum(), 0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Summary:

- Distinction between global shells (based on all distances) and local shells (based on the distances of each atom) and `shells` now calls `get_local_shells` internally.
- `get_shell_matrix` now returns a list of sparse matrices (which hopefully will solve the memory issues Qais and I were encountering)
- `update_vectors` will update `vecs` and `distances` for the same indices without having to execute `get_neighbors` again. This works only if the largest distance is smaller than half the length in any direction (I'll explain why at the pyiron meeting)
- clustering methods we studied some time ago are now included in the class. They can be called as a child function from `get_local_shells` or `get_global_shells` or they can be called separately by `cluster_by_xxx` (the latter will allow for more fine adjustments of parameters). As the clustering methods could be very heavy, the results are stored and calling `get_xxx_shells` twice does not execute the algorithm again. In order to force the system to do so, you have to reset the results via `reset_clusters` or call `cluster_xxx` separately.