### PR TITLE
pyiron_base 0.1.19

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - phonopy =2.4.2
   - psutil =5.7.0
   - pyfileindex =0.0.4
-  - pyiron_base =0.1.18
+  - pyiron_base =0.1.19
   - pyscal =2.7.5
   - pysqa =0.0.11
   - pytables =3.6.1

--- a/.ci_support/travis_setup_notebooks.sh
+++ b/.ci_support/travis_setup_notebooks.sh
@@ -3,8 +3,5 @@
 # Install additional requirements 
 conda env update --name root --file .ci_support/environment-notebooks.yml
 
-# Create .pyiron config
-printf "[DEFAULT]\nTOP_LEVEL_DIRS = ${HOME}\nRESOURCE_PATHS =$HOME/miniconda/share/pyiron" > ${HOME}/.pyiron
-
 # Remove excluded notebooks 
 for f in $(cat .ci_support/exclude); do rm notebooks/$f; done;

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -9,9 +9,6 @@ jupyter nbextension enable nglview --py --sys-prefix
 jupyter labextension install @jupyter-widgets/jupyterlab-manager --no-build
 jupyter labextension install nglview-js-widgets
 
-# pyiron setup
-printf "[DEFAULT]\nTOP_LEVEL_DIRS = ${HOME}\nRESOURCE_PATHS = /srv/conda/envs/notebook/share/pyiron" > ${HOME}/.pyiron
-
 # clean up
 if [ -d "notebooks" ]; then
     mv notebooks/* .

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'phonopy>=2.4.2',
         'psutil>=5.7.0',
         'pyfileindex>=0.0.4',
-        'pyiron_base>=0.1.18',
+        'pyiron_base>=0.1.19',
         'pysqa>=0.0.11',
         'quickff>=2.2.4',
         'scipy>=1.4.1',


### PR DESCRIPTION
By switching to pyiron_base 0.1.19 it is no longer necessary to create a `.pyiron` file as the pyiron resources are also installed via conda.