### PR TITLE
Find neighbors

### DIFF
--- a/pyiron/atomistics/structure/neighbors.py
+++ b/pyiron/atomistics/structure/neighbors.py
@@ -206,10 +206,13 @@ class Neighbors(object):
             # in each direction.
         """
 
-        dist = np.linalg.norm(self.vecs-np.array(vector), axis=-1)
+        z = np.zeros(len(self._ref_structure)*3).reshape(-1, 3)
+        v = np.append(z[:,np.newaxis,:], self.vecs, axis=1)
+        dist = np.linalg.norm(v-np.array(vector), axis=-1)
+        indices = np.append(np.arange(len(self._ref_structure))[:,np.newaxis], self.indices, axis=1)
         if deviation:
-            return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)], np.min(dist, axis=-1)
-        return self.indices[np.arange(len(dist)), np.argmin(dist, axis=-1)]
+            return indices[np.arange(len(dist)), np.argmin(dist, axis=-1)], np.min(dist, axis=-1)
+        return indices[np.arange(len(dist)), np.argmin(dist, axis=-1)]
 
     def cluster_by_vecs(self, bandwidth=None, n_jobs=None, max_iter=300):
         """

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -700,11 +700,9 @@ class TestAtoms(unittest.TestCase):
                       scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)],
                       cell=np.identity(3),
                       pbc=True)
-        id_lst, dist = basis.find_neighbors_by_vector([0, 0, 1],
-                                                      deviation=True,
-                                                      num_neighbors=14)
+        id_lst = basis.find_neighbors_by_vector([0, 0, 1],
+                                                num_neighbors=14)
         self.assertEqual(len(np.unique(np.unique(id_lst, return_counts=True)[1])), 1)
-        self.assertLess(np.linalg.norm(dist), 1.0e-4)
 
     def test_get_neighborhood(self):
         basis = Atoms(

--- a/tests/atomistics/structure/test_neighbors.py
+++ b/tests/atomistics/structure/test_neighbors.py
@@ -124,5 +124,18 @@ class TestAtoms(unittest.TestCase):
         self.assertTrue(np.array_equal(np.sort(bonds[0]['Al'][0]),
                         np.sort(neigh.indices[0, neigh.shells[0]==1])))
 
+    def test_find_neighbors_by_vector(self):
+        basis = Atoms(symbols=2*["Fe"],
+                      scaled_positions=[(0, 0, 0), (0.5, 0.5, 0.5)],
+                      cell=np.identity(3),
+                      pbc=True)
+        neigh = basis.get_neighbors(num_neighbors=14)
+        id_lst, dist = neigh.find_neighbors_by_vector([0, 0, 1],
+                                                      deviation=True)
+        self.assertEqual(len(np.unique(np.unique(id_lst, return_counts=True)[1])), 1)
+        self.assertLess(np.linalg.norm(dist), 1.0e-4)
+        id_lst = neigh.find_neighbors_by_vector([0, 0, 0])
+        self.assertTrue(np.array_equal(id_lst, np.arange(len(basis))))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`find_neighbors_by_vector` now correctly identifies the atoms themselves if the given vector is very small.