### PR TITLE
Vasp parse elastic constants

### DIFF
--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1911,7 +1911,8 @@ class Output:
         if outcar_working:
             log_dict["temperature"] = self.outcar.parse_dict["temperatures"]
             log_dict["pressures"] = self.outcar.parse_dict["pressures"]
-            log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
+            if self.outcar.parse_dict["elastic_constants"] != None:
+                log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
             self.generic_output.dft_log_dict["n_elect"] = self.outcar.parse_dict[
                 "n_elect"
             ]

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1911,6 +1911,7 @@ class Output:
         if outcar_working:
             log_dict["temperature"] = self.outcar.parse_dict["temperatures"]
             log_dict["pressures"] = self.outcar.parse_dict["pressures"]
+            log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
             self.generic_output.dft_log_dict["n_elect"] = self.outcar.parse_dict[
                 "n_elect"
             ]

--- a/pyiron/vasp/base.py
+++ b/pyiron/vasp/base.py
@@ -1911,8 +1911,7 @@ class Output:
         if outcar_working:
             log_dict["temperature"] = self.outcar.parse_dict["temperatures"]
             log_dict["pressures"] = self.outcar.parse_dict["pressures"]
-            if self.outcar.parse_dict["elastic_constants"] != None:
-                log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
+            log_dict["elastic_constants"] = self.outcar.parse_dict["elastic_constants"]
             self.generic_output.dft_log_dict["n_elect"] = self.outcar.parse_dict[
                 "n_elect"
             ]

--- a/pyiron/vasp/outcar.py
+++ b/pyiron/vasp/outcar.py
@@ -65,7 +65,6 @@ class Outcar(object):
         n_elect = self.get_nelect(filename=filename, lines=lines)
         e_fermi_list, vbm_list, cbm_list = self.get_band_properties(filename=filename, lines=lines)
         elastic_constants = self.get_elastic_constants(filename=filename, lines=lines)
-        
         try:
             irreducible_kpoints = self.get_irreducible_kpoints(
                 filename=filename, lines=lines
@@ -101,7 +100,6 @@ class Outcar(object):
         self.parse_dict["vbm_list"] = vbm_list
         self.parse_dict["cbm_list"] = cbm_list
         self.parse_dict["elastic_constants"] = elastic_constants
-
         try:
             self.parse_dict["pressures"] = (
                 np.average(stresses[:, 0:3], axis=1) * KBAR_TO_EVA
@@ -833,7 +831,6 @@ class Outcar(object):
             elastic_GPa = np.array(elastic_constants, dtype=float) / 10  
             return elastic_GPa
      
-
     @staticmethod
     def _get_positions_and_forces_parser(
         lines, trigger_indices, n_atoms, pos_flag=True, force_flag=True

--- a/pyiron/vasp/outcar.py
+++ b/pyiron/vasp/outcar.py
@@ -65,6 +65,7 @@ class Outcar(object):
         n_elect = self.get_nelect(filename=filename, lines=lines)
         e_fermi_list, vbm_list, cbm_list = self.get_band_properties(filename=filename, lines=lines)
         elastic_constants = self.get_elastic_constants(filename=filename, lines=lines)
+        
         try:
             irreducible_kpoints = self.get_irreducible_kpoints(
                 filename=filename, lines=lines
@@ -829,7 +830,8 @@ class Outcar(object):
             elastic_constants = []
             for line in lines[start_index:end_index]:
                 elastic_constants.append(line.split()[1:])
-            return np.array(elastic_constants) / 10 #kBar in GPa
+            elastic_GPa = np.array(elastic_constants, dtype=float) / 10  
+            return elastic_GPa
      
 
     @staticmethod


### PR DESCRIPTION
This parses the total elastic constants calculated to the hdf if they were calculated using IBRION= 6 . Maybe it would be interesting to divide between clamped elastic constants and ionic contributions but I don't know how to do that in a nice style.