### PR TITLE
lowered flush frequency

### DIFF
--- a/pyiron/sphinx/interactive.py
+++ b/pyiron/sphinx/interactive.py
@@ -37,6 +37,7 @@ class SphinxInteractive(SphinxBase, GenericInteractive):
         self._interactive_write_input_files = True
         self._interactive_library_read = None
         self._interactive_fetch_completed = True
+        self.interactive_flush_frequency = 1
 
     @property
     def structure(self):

--- a/pyiron/vasp/interactive.py
+++ b/pyiron/vasp/interactive.py
@@ -33,6 +33,7 @@ class VaspInteractive(VaspBase, GenericInteractive):
         super(VaspInteractive, self).__init__(project, job_name)
         self._interactive_write_input_files = True
         self._interactive_vasprun = None
+        self.interactive_flush_frequency = 1
 
     @property
     def structure(self):


### PR DESCRIPTION
I got a few SPHInX simulations which didn't converge within the run time limit. Then I realized that the general flush frequency was raised to 10,000 before (did I do it?) and all information stored in `interactive_cache` was lost. Now the default is set to 1 inside SPHInX.

@sudarsan-surendralal : I'm sure that the same thing should be done in VASP