### PR TITLE
Attempt to fix issue related to using ASE atom

### DIFF
--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -7,6 +7,7 @@ import warnings
 from pyiron_base import GenericParameters, GenericJob, GenericMaster
 from pyiron.atomistics.structure.atoms import ase_to_pyiron
 from ase import Atoms as ASEAtoms
+from pyiron.atomistics.structure.atoms import Atoms as PAtoms
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
@@ -164,11 +165,11 @@ class InteractiveWrapper(GenericMaster):
         """
         db_dict = super(InteractiveWrapper, self).db_entry()
         if self.structure:
-            if isinstance(self.structure, ASEAtoms):
+            if isinstance(self.structure, PAtoms):
+                parent_structure = self.structure.get_parent_basis()
+            else:
                 parent_structure = ase_to_pyiron(self.structure)
                 parent_structure = parent_structure.get_parent_basis()
-            else:
-                parent_structure = self.structure.get_parent_basis()
             db_dict["ChemicalFormula"] = parent_structure.get_chemical_formula()
         return db_dict
 

--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import warnings
 from pyiron_base import GenericParameters, GenericJob, GenericMaster
 from pyiron.atomistics.structure.atoms import ase_to_pyiron
-from ase import Atoms as ASEAtoms
 from pyiron.atomistics.structure.atoms import Atoms as PAtoms
 
 __author__ = "Osamu Waseda, Jan Janssen"

--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -5,6 +5,8 @@
 from datetime import datetime
 import warnings
 from pyiron_base import GenericParameters, GenericJob, GenericMaster
+from pyiron.atomistics.structure.atoms import ase_to_pyiron
+from ase import Atoms as ASEAtoms
 
 __author__ = "Osamu Waseda, Jan Janssen"
 __copyright__ = (
@@ -162,7 +164,11 @@ class InteractiveWrapper(GenericMaster):
         """
         db_dict = super(InteractiveWrapper, self).db_entry()
         if self.structure:
-            parent_structure = self.structure.get_parent_basis()
+            if type(self.structure) == ASEAtoms:
+                parent_structure = ase_to_pyiron(self.structure)
+                parent_structure = parent_structure.get_parent_basis()
+            else:
+                parent_structure = self.structure.get_parent_basis()
             db_dict["ChemicalFormula"] = parent_structure.get_chemical_formula()
         return db_dict
 

--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -167,7 +167,7 @@ class InteractiveWrapper(GenericMaster):
             if isinstance(self.structure, PAtoms):
                 parent_structure = self.structure.get_parent_basis()
             else:
-                parent_structure = ase_to_pyiron(self.structure)
+                parent_structure = ase_to_pyiron(self.structure).get_parent_basis()
                 parent_structure = parent_structure.get_parent_basis()
             db_dict["ChemicalFormula"] = parent_structure.get_chemical_formula()
         return db_dict

--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -168,7 +168,6 @@ class InteractiveWrapper(GenericMaster):
                 parent_structure = self.structure.get_parent_basis()
             else:
                 parent_structure = ase_to_pyiron(self.structure).get_parent_basis()
-                parent_structure = parent_structure.get_parent_basis()
             db_dict["ChemicalFormula"] = parent_structure.get_chemical_formula()
         return db_dict
 

--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -164,7 +164,7 @@ class InteractiveWrapper(GenericMaster):
         """
         db_dict = super(InteractiveWrapper, self).db_entry()
         if self.structure:
-            if type(self.structure) == ASEAtoms:
+            if isinstance(self.structure, ASEAtoms):
                 parent_structure = ase_to_pyiron(self.structure)
                 parent_structure = parent_structure.get_parent_basis()
             else:


### PR DESCRIPTION
This fixes an issue when trying to run a gpaw job in interactive mode, that occurs because the pyiron atoms object is converted to an ASE atoms object at some point. This feels like an ugly workaround and there is probably a better fix for this so any suggestions are very welcome.