### PR TITLE
Fix LAMMPS pressure

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -315,7 +315,6 @@ class LammpsControl(GenericParameters):
             raise NotImplementedError
         energy_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["energy"]
         force_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"]
-        pressure_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
 
         ionic_energy_tolerance *= energy_units
         ionic_force_tolerance *= force_units
@@ -328,7 +327,7 @@ class LammpsControl(GenericParameters):
                 str_press = ""
                 for press, str_axis in zip(pressure, [" x ", " y ", " z ", " xy ", " xz ", " yz "]):
                     if press is not None:
-                        str_press += str_axis + str(press*pressure_units )
+                        str_press += str_axis + str(press)
                 if len(str_press) > 1:
                     str_press += " couple none"
             self.set(fix___ensemble=r"all box/relax" + str_press)

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -242,7 +242,7 @@ class LammpsControl(GenericParameters):
                  [pxz, pyz, pzz]]
             )
             lammps_pressure_tensor = rotation_matrix.T @ pressure_tensor @ rotation_matrix
-                pressure = list(lammps_pressure_tensor[[0, 1, 2, 0, 0, 1], [0, 1, 2, 1, 2, 2]])
+            pressure = list(lammps_pressure_tensor[[0, 1, 2, 0, 0, 1], [0, 1, 2, 1, 2, 2]])
 
         return [(p * LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
                  if p is not None

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -222,11 +222,13 @@ class LammpsControl(GenericParameters):
         if np.isscalar(pressure):
             return float(pressure) * LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
 
-        # Normalize pressure to a list of 6 entries.
+        # Normalize pressure to a list of 6 entries of either float or NoneType type.
         if len(pressure) > 6:
             raise ValueError("Pressure can have a maximum of 6 values, (x, y, z, xy, xz, and yz), but got " +
                              "{}".format(len(pressure)))
-        pressure = list(pressure) + (6 - len(pressure)) * [None]
+        pressure = [float(p) if p is not None else None
+                    for p in pressure]
+        pressure += (6 - len(pressure)) * [None]
 
         if all(p is None for p in pressure):
             raise ValueError("Pressure cannot have a length but all be None")

--- a/tests/lammps/test_base.py
+++ b/tests/lammps/test_base.py
@@ -534,6 +534,12 @@ class TestLammps(unittest.TestCase):
         self.minimize_control_job.calc_minimize(pressure=0)
         self.assertEqual(
             self.minimize_control_job.input.control['fix___ensemble'],
+            "all box/relax iso 0.0"
+        )
+
+        self.minimize_control_job.calc_minimize(pressure=[0.0, 0.0, 0.0])
+        self.assertEqual(
+            self.minimize_control_job.input.control['fix___ensemble'],
             "all box/relax x 0.0 y 0.0 z 0.0 couple none"
         )
 

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -48,12 +48,12 @@ class TestLammps(unittest.TestCase):
 
     def test_pressure_to_lammps(self):
         lc = LammpsControl()
-        # Correct normalization without rotation.
+        # Correct normalization without rotation. Note that we convert from GPa to bar for LAMMPS.
         no_rot = np.identity(3)
-        self.assertEqual(lc.pressure_to_lammps(1.0, no_rot), [1.0, 1.0, 1.0, None, None, None])
-        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0], no_rot), [1.0, 2.0, 3.0, None, None, None])
-        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0, None, None, None], no_rot), [1.0, 2.0, 3.0, None, None, None])
-        self.assertEqual(lc.pressure_to_lammps([None, None, None, None, None, 2.0], no_rot), [None, None, None, None, None, 2.0])        
+        self.assertEqual(lc.pressure_to_lammps(1.0, no_rot), [10000.0, 10000.0, 10000.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0], no_rot), [10000.0, 20000.0, 30000.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0, None, None, None], no_rot), [10000.0, 20000.0, 30000.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([None, None, None, None, None, 2.0], no_rot), [None, None, None, None, None, 20000.0])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -2,6 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
+import numpy as np
 import unittest
 from pyiron.lammps.control import LammpsControl
 
@@ -45,6 +46,14 @@ class TestLammps(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             lc.measure_mean_value('something')
 
+    def test_pressure_to_lammps(self):
+        lc = LammpsControl()
+        # Correct normalization without rotation.
+        no_rot = np.identity(3)
+        self.assertEqual(lc.pressure_to_lammps(1.0, no_rot), [1.0, 1.0, 1.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0], no_rot), [1.0, 2.0, 3.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([1.0, 2.0, 3.0, None, None, None], no_rot), [1.0, 2.0, 3.0, None, None, None])
+        self.assertEqual(lc.pressure_to_lammps([None, None, None, None, None, 2.0], no_rot), [None, None, None, None, None, 2.0])        
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/lammps/test_interactive.py
+++ b/tests/lammps/test_interactive.py
@@ -108,6 +108,11 @@ class TestLammpsInteractive(unittest.TestCase):
         # Ensure that pressure inputs are being parsed OK
         self.minimize_job.calc_minimize(pressure=0)
         self.minimize_job._interactive_lammps_input()
+        self.assertTrue(("fix ensemble all box/relax iso 0.0" in
+                         self.minimize_job._interactive_library._command))
+
+        self.minimize_job.calc_minimize(pressure=[0.0, 0.0, 0.0])
+        self.minimize_job._interactive_lammps_input()
         self.assertTrue(("fix ensemble all box/relax x 0.0 y 0.0 z 0.0 couple none" in
                          self.minimize_job._interactive_library._command))
 


### PR DESCRIPTION
As discussed in bug #1074, a LAMMPS job converted the `pressure` input to a numpy array of type float, thereby converting `None` values to NaN, which was not checked correctly by later parts of the code.

Furthermore, hydrostatic pressures were handled incorrectly, by converting a scalar pressure p to a stress tensor [p,p,p,p,p,p] instead of [p,p,p,0,0,0] or [p,p,p,None,None,None] in some circumstances.

To be discussed: I believe that hydrostatic pressures can be applied correctly in all cases (even with rotation) by using [p,p,p,None,None,None], i.e., keeping the shear components fixed. I am not 100% sure it works when rotating the box, so if there is no consensus I would propose to disallow even hydrostatic pressure when the box has to be rotated and require a full stress tensor. The previous code was inconsistent in the different cases, which is worse.