### PR TITLE
No double units

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -308,7 +308,7 @@ class LammpsControl(GenericParameters):
             str_press = ""
             for press, str_axis in zip(pressure, [" x ", " y ", " z ", " xy ", " xz ", " yz "]):
                 if press is not None:
-                    str_press += str_axis + str(press*pressure_units )
+                    str_press += str_axis + str(press)
             if len(str_press) == 0:
                 raise ValueError("Pressure values cannot all be None")
             elif len(str_press) > 1:

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -294,7 +294,6 @@ class LammpsControl(GenericParameters):
             raise NotImplementedError
         energy_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["energy"]
         force_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"]
-        pressure_units = LAMMPS_UNIT_CONVERSIONS[self["units"]]["pressure"]
 
         ionic_energy_tolerance *= energy_units
         ionic_force_tolerance *= force_units

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -3,10 +3,33 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 import unittest
-from pyiron.lammps.control import LammpsControl
+from pyiron.lammps.control import LammpsControl, LAMMPS_UNIT_CONVERSIONS
+import numpy as np
 
 
 class TestLammps(unittest.TestCase):
+    def test_calc_minimize(self):
+        lc = LammpsControl()
+        p = 1
+        lc.calc_minimize(pressure=p, rotation_matrix=np.eye(3))
+        self.assertTrue(
+            np.isclose(
+                float(lc['fix___ensemble'].split(' x ')[1].split(' ')[0]),
+                p * LAMMPS_UNIT_CONVERSIONS[lc["units"]]["pressure"]
+            )
+        )
+
+    def test_calc_md(self):
+        lc = LammpsControl()
+        p = 1
+        lc.calc_md(temperature=300, pressure=p, rotation_matrix=np.eye(3))
+        self.assertTrue(
+            np.isclose(
+                float(lc['fix___ensemble'].split(' x ')[1].split(' ')[0]),
+                p * LAMMPS_UNIT_CONVERSIONS[lc["units"]]["pressure"]
+            )
+        )
+
     def test_generate_seed_from_job(self):
         lc = LammpsControl()
         job_hash_dict = {


### PR DESCRIPTION
We were converting to Lammps pressure units twice in `calc_minimize`! No more.

Not in the scope of this PR: testing anything except that the pressure units are being converted to the control field correctly.