### PR TITLE
Fix #1093

### DIFF
--- a/pyiron/atomistics/structure/_visualize.py
+++ b/pyiron/atomistics/structure/_visualize.py
@@ -6,6 +6,7 @@ import numpy as np
 import warnings
 from matplotlib.colors import rgb2hex
 from pyiron_base import Settings
+from pyiron_base.generic.util import Singleton
 from scipy.interpolate import interp1d
 
 __author__ = "Joerg Neugebauer, Sudarsan Surendralal"
@@ -21,7 +22,7 @@ __date__ = "Sep 1, 2017"
 
 s = Settings()
 
-class Visualize:
+class Visualize(Singleton):
     def __init__(self, atoms):
         self._ref_atoms = atoms
 

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -192,7 +192,6 @@ class Atoms(ASEAtoms):
             self.dimension = len(self.positions[0])
         else:
             self.dimension = 0
-        self.visualize = Visualize(self)
 
     @property
     def species(self):
@@ -1020,6 +1019,10 @@ class Atoms(ASEAtoms):
         )
         return analyse_phonopy_equivalent_atoms(atoms)
 
+    @property
+    def _visualize(self):
+        return Visualize(self)
+
     def plot3d(
         self,
         mode='NGLview',
@@ -1043,7 +1046,7 @@ class Atoms(ASEAtoms):
         distance_from_camera=1.0,
         opacity=1.0
     ):
-        return self.visualize.plot3d(
+        return self._visualize.plot3d(
             mode=mode,
             show_cell=show_cell,
             show_axes=show_axes,
@@ -1998,7 +2001,6 @@ class Atoms(ASEAtoms):
         for key, val in self.__dict__.items():
             if key not in ase_keys:
                 atoms_new.__dict__[key] = copy(val)
-        atoms_new.visualize = Visualize(atoms_new)
         return atoms_new
 
     def __delitem__(self, key):
@@ -2480,7 +2482,6 @@ class Atoms(ASEAtoms):
             dummy_basis = copy(self)
             dummy_basis.rotate(a=a, v=v, center=center, rotate_cell=rotate_cell)
             self.positions[index_list] = dummy_basis.positions[index_list]
-
 
 class _CrystalStructure(Atoms):
     """


### PR DESCRIPTION
The underlying problem is that `Atoms.__copy__` copies the `Visualize`
class, but does not set a the new `Atoms` object as its reference.
However since `Visualize` does not keep any state expect that reference,
we can side-step this problem by making `Atoms.visualize` a property
that returns a new `Visualize` instance on the fly.  To avoid
unnecessary instantiations `Visualize` is now a singleton.  I also went
ahead and renamed the member to `_visualize` since it is not documented
and we labeled the whole module where it comes from as internal.

This effectively reverts PR #1098.  Since this avoid special casing `Atoms.visualize` in the copy method, I thought this was a bit neater.