### PR TITLE
scaled positions changed to positions

### DIFF
--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -174,8 +174,8 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
 
     def interactive_positions_organizer(self):
         if not np.allclose(
-            self._structure_current.get_scaled_positions(),
-            self._structure_previous.get_scaled_positions(),
+            self._structure_current.positions,
+            self._structure_previous.positions,
             rtol=1e-15,
             atol=1e-15,
         ):


### PR DESCRIPTION
Closes #1145 

The problem was related to the old implementation (I guess) where we distinguished between relative scale and absolute scale. Now since we have only the absolute system, the real positions should be checked instead of relative positions.