### PR TITLE
[ci skip] Update old syntax of importing Project in tutorials notebooks

### DIFF
--- a/notebooks/bandstructure.ipynb
+++ b/notebooks/bandstructure.ipynb
@@ -25,7 +25,7 @@
    },
    "outputs": [],
    "source": [
-    "from pyiron.project import Project\n",
+    "from pyiron import Project\n",
     "from ase.spacegroup import crystal\n",
     "import matplotlib.pyplot as plt\n",
     "import seekpath as sp\n",

--- a/notebooks/first_steps.ipynb
+++ b/notebooks/first_steps.ipynb
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "from pyiron.project import Project"
+    "from pyiron import Project"
    ]
   },
   {

--- a/notebooks/hcp_workfunction.ipynb
+++ b/notebooks/hcp_workfunction.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyiron.project import Project"
+    "from pyiron import Project"
    ]
   },
   {

--- a/notebooks/phonopy_example.ipynb
+++ b/notebooks/phonopy_example.ipynb
@@ -21,7 +21,7 @@
    "outputs": [],
    "source": [
     "# Generic imports\n",
-    "from pyiron.project import Project\n",
+    "from pyiron import Project\n",
     "import numpy as np\n",
     "%matplotlib  inline\n",
     "import matplotlib.pylab as plt\n",

--- a/notebooks/structures.ipynb
+++ b/notebooks/structures.ipynb
@@ -59,7 +59,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pyiron.project import Project\n",
+    "from pyiron import Project\n",
     "pr = Project(path='structures')"
    ]
   },

--- a/notebooks/water_MD.ipynb
+++ b/notebooks/water_MD.ipynb
@@ -19,7 +19,7 @@
     "import numpy as np\n",
     "%matplotlib inline \n",
     "import matplotlib.pylab as plt\n",
-    "from pyiron.project import Project\n",
+    "from pyiron import Project\n",
     "import ase.units as units\n",
     "import pandas"
    ]


### PR DESCRIPTION
Replaced `from pyiron.project import Project` with `from pyiron import Project` in tutorials notebooks to be consistent with pyiron.org snippet