### PR TITLE
Fix neighbors

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1233,7 +1233,7 @@ class Atoms(ASEAtoms):
             volume_per_atom = self.get_volume(per_atom=True)
             if id_list is not None:
                 volume_per_atom = self.get_volume() / len(id_list)
-            num_neighbors = max(1, int((4 + num_neighbors_estimate_buffer) *
+            num_neighbors = max(4, int((1 + num_neighbors_estimate_buffer) *
                                        4. / 3. * np.pi * cutoff_radius ** 3 / volume_per_atom))
 
         neigh = self._get_neighbors(

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1233,7 +1233,7 @@ class Atoms(ASEAtoms):
             volume_per_atom = self.get_volume(per_atom=True)
             if id_list is not None:
                 volume_per_atom = self.get_volume() / len(id_list)
-            num_neighbors = max(1, int((1 + num_neighbors_estimate_buffer) *
+            num_neighbors = max(1, int((4 + num_neighbors_estimate_buffer) *
                                        4. / 3. * np.pi * cutoff_radius ** 3 / volume_per_atom))
 
         neigh = self._get_neighbors(

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1200,7 +1200,6 @@ class Atoms(ASEAtoms):
                     num_neighbors = 2 * num_neighbors
         return num_neighbors_per_atom
 
-
     def get_neighbors_by_distance(
         self,
         cutoff_radius=5,
@@ -1234,8 +1233,8 @@ class Atoms(ASEAtoms):
             volume_per_atom = self.get_volume(per_atom=True)
             if id_list is not None:
                 volume_per_atom = self.get_volume() / len(id_list)
-            num_neighbors = int((1 + num_neighbors_estimate_buffer) *
-                                4. / 3. * np.pi * cutoff_radius ** 3 / volume_per_atom)
+            num_neighbors = max(1, int((1 + num_neighbors_estimate_buffer) *
+                                       4. / 3. * np.pi * cutoff_radius ** 3 / volume_per_atom))
 
         neigh = self._get_neighbors(
             num_neighbors=num_neighbors,
@@ -1338,7 +1337,7 @@ class Atoms(ASEAtoms):
             and vectors
 
         """
-        if num_neighbors<1:
+        if num_neighbors < 1:
             raise ValueError('num_neighbors must be a positive integer')
         boxsize = None
         num_neighbors += 1

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -780,6 +780,16 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(len(neigh.distances[2]), 5)
         with self.assertRaises(ValueError):
             basis.get_neighbors_by_distance(num_neighbors_estimate_buffer=-1)
+        # Check with large cell with few atoms
+        dx = 0.7
+        r_O = [0, 0, 0]
+        r_H1 = [dx, dx, 0]
+        r_H2 = [-dx, dx, 0]
+        unit_cell = 10 * np.eye(3)
+        water = Atoms(elements=['H', 'H', 'O'],
+                                positions=[r_H1, r_H2, r_O],
+                                cell=unit_cell, pbc=True)
+        water.get_neighbors_by_distance(1.3)
 
     def test_get_number_of_neighbors_in_sphere(self):
         basis = Atoms(symbols="FeFeFe", positions=[3 * [0], 3 * [1], [0, 0, 1]], cell=2 * np.eye(3), pbc=True)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -786,10 +786,8 @@ class TestAtoms(unittest.TestCase):
         r_H1 = [dx, dx, 0]
         r_H2 = [-dx, dx, 0]
         unit_cell = 10 * np.eye(3)
-        water = Atoms(elements=['H', 'H', 'O'],
-                                positions=[r_H1, r_H2, r_O],
-                                cell=unit_cell, pbc=True)
-        water.get_neighbors_by_distance(1.3)
+        water = Atoms(elements=['H', 'H', 'O'], positions=[r_H1, r_H2, r_O], cell=unit_cell, pbc=True)
+        self.assertIsInstance(water.get_neighbors_by_distance(1.3).indices, list)
 
     def test_get_number_of_neighbors_in_sphere(self):
         basis = Atoms(symbols="FeFeFe", positions=[3 * [0], 3 * [1], [0, 0, 1]], cell=2 * np.eye(3), pbc=True)


### PR DESCRIPTION
The current implementation of `get_neighbors_by_distance` would fail in cases where the volume per atom of the supercell is large. For example

```
import numpy as np
from pyiron import Project

pr = Project(".")
dx = 0.7
r_O = [0, 0, 0]
r_H1 = [dx, dx, 0]
r_H2 = [-dx, dx, 0]
unit_cell = 10 * np.eye(3)
water = pr.create_atoms(elements=['H', 'H', 'O'],
                        positions=[r_H1, r_H2, r_O],
                        cell=unit_cell, pbc=True)
water.get_neighbors_by_distance(1.3)
```

I've just made a simple fix so that at least 1 neighbor is counted.