### PR TITLE
Debug no neigh

### DIFF
--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1378,9 +1378,11 @@ class Atoms(ASEAtoms):
                 neighbor_obj.vecs = neighbor_obj.vecs-np.rint(neighbor_obj.vecs)
                 neighbor_obj.vecs *= self.cell.diagonal()
             if any(self.pbc):
-                vecs = neighbor_obj.vecs.reshape(-1, 3)[neighbor_obj.distances.flatten()<np.inf]
-                if np.absolute(vecs[:,self.pbc]).max()>width:
-                    warnings.warn('boundary_width_factor may have been too small - most likely not all neighbors properly assigned')
+                vecs = neighbor_obj.vecs.reshape(-1, 3)[neighbor_obj.distances.flatten() < np.inf]
+                if len(vecs) > 0:
+                    if np.absolute(vecs[:, self.pbc]).max() > width:
+                        warnings.warn('boundary_width_factor may have been too small - '
+                                      'most likely not all neighbors properly assigned')
         return neighbor_obj
 
     def get_neighborhood(

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -788,6 +788,8 @@ class TestAtoms(unittest.TestCase):
         unit_cell = 10 * np.eye(3)
         water = Atoms(elements=['H', 'H', 'O'], positions=[r_H1, r_H2, r_O], cell=unit_cell, pbc=True)
         self.assertIsInstance(water.get_neighbors_by_distance(1.3).indices, list)
+        water_new = water[[0, 1]]
+        self.assertTrue(np.array_equal(water_new.get_neighbors_by_distance(1.3).indices, [np.array([]), np.array([])]))
 
     def test_get_number_of_neighbors_in_sphere(self):
         basis = Atoms(symbols="FeFeFe", positions=[3 * [0], 3 * [1], [0, 0, 1]], cell=2 * np.eye(3), pbc=True)


### PR DESCRIPTION
The check for the warning previously failed if there aren't any neighbors to return