### PR TITLE
Add check that reference job is static

### DIFF
--- a/pyiron/atomistics/master/phonopy.py
+++ b/pyiron/atomistics/master/phonopy.py
@@ -393,3 +393,10 @@ class PhonopyJob(AtomisticParallelMaster):
         ax.set_ylabel("DOS")
         ax.set_title("Phonon DOS vs Energy")
         return ax
+
+    def validate_ready_to_run(self):
+        if self.ref_job._generic_input["calc_mode"] != "static":
+            raise ValueError("Phonopy reference jobs should be static calculations, but got {}".format(
+                self.ref_job._generic_input["calc_mode"]
+            ))
+        super().validate_ready_to_run()

--- a/tests/atomistics/master/test_phonopy.py
+++ b/tests/atomistics/master/test_phonopy.py
@@ -39,7 +39,7 @@ class TestPhonopy(unittest.TestCase):
         job.structure.set_repeat(rep)
         job.set_force_constants(1)
         # phono.run() # removed because somehow it's extremely slow
-        
+
     def test_non_static_ref_job(self):
         structure = CrystalStructure(
             element="Al", bravais_basis="fcc", lattice_constant=4.5

--- a/tests/atomistics/master/test_phonopy.py
+++ b/tests/atomistics/master/test_phonopy.py
@@ -39,7 +39,19 @@ class TestPhonopy(unittest.TestCase):
         job.structure.set_repeat(rep)
         job.set_force_constants(1)
         # phono.run() # removed because somehow it's extremely slow
-
+        
+    def test_non_static_ref_job(self):
+        structure = CrystalStructure(
+            element="Al", bravais_basis="fcc", lattice_constant=4.5
+        )
+        phon_ref_job = self.project.create_job('Lammps', 'ref_job')
+        phon_ref_job.structure = structure
+        phon_ref_job.potential = phon_ref_job.list_potentials()[0]
+        phon_ref_job.calc_minimize()
+        phonopy_job = self.project.create_job("PhonopyJob",'phonopy_job')
+        phonopy_job.ref_job = phon_ref_job
+        with self.assertRaises(ValueError):
+            phonopy_job.validate_ready_to_run()
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
If you pass a `calc_md` or `calc_minimize` job as a phonopy reference, phonopy will run but will silently return crazy results (at least for minimize, not 100% sure for md). Let's stop that by validating the input.

I draft the solution here, but don't have time to test it and bring it all the way home. I think this is an excellent topic for one of our junior developers to take over and finish this PR!

[Linked issue](https://github.com/pyiron/pyiron/issues/1195).