### PR TITLE
Spinoff structures

### DIFF
--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -3,7 +3,7 @@ __all__ = []
 
 from pyiron.project import Project
 from pyiron.atomistics.structure.atoms import ase_to_pyiron, pyiron_to_ase, Atoms
-from pyiron.atomistics.structure.generator import create_surface, create_ase_bulk, create_structure
+from pyiron.atomistics.structure.generator import StructureGenerator  # create_surface, create_ase_bulk, create_structure
 from pyiron_base import Notebook, install_dialog, JOB_CLASS_DICT
 
 

--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -3,7 +3,7 @@ __all__ = []
 
 from pyiron.project import Project
 from pyiron.atomistics.structure.atoms import ase_to_pyiron, pyiron_to_ase, Atoms
-from pyiron.atomistics.structure.factory import StructureFactory  # create_surface, create_ase_bulk, create_structure
+from pyiron.atomistics.structure.factory import StructureFactory
 from pyiron_base import Notebook, install_dialog, JOB_CLASS_DICT
 
 

--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -3,7 +3,7 @@ __all__ = []
 
 from pyiron.project import Project
 from pyiron.atomistics.structure.atoms import ase_to_pyiron, pyiron_to_ase, Atoms
-from pyiron.atomistics.structure.generator import StructureGenerator  # create_surface, create_ase_bulk, create_structure
+from pyiron.atomistics.structure.factory import StructureFactory  # create_surface, create_ase_bulk, create_structure
 from pyiron_base import Notebook, install_dialog, JOB_CLASS_DICT
 
 

--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -11,8 +11,6 @@ create_surface = _StructureFactory.surface
 create_ase_bulk = _StructureFactory.ase_bulk
 create_structure = _StructureFactory.crystal
 
-
-
 # Make classes available for new pyiron version
 JOB_CLASS_DICT["ART"] = "pyiron.interactive.activation_relaxation_technique"
 JOB_CLASS_DICT["Atoms"] = "pyiron.atomistics.structure.atoms"

--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -3,7 +3,6 @@ __all__ = []
 
 from pyiron.project import Project
 from pyiron.atomistics.structure.atoms import ase_to_pyiron, pyiron_to_ase, Atoms
-from pyiron.atomistics.structure.factory import StructureFactory
 from pyiron_base import Notebook, install_dialog, JOB_CLASS_DICT
 
 

--- a/pyiron/__init__.py
+++ b/pyiron/__init__.py
@@ -5,6 +5,13 @@ from pyiron.project import Project
 from pyiron.atomistics.structure.atoms import ase_to_pyiron, pyiron_to_ase, Atoms
 from pyiron_base import Notebook, install_dialog, JOB_CLASS_DICT
 
+# To maintain backwards compatibility until we deprecate the old structure creation functions:
+from pyiron.atomistics.structure.factory import StructureFactory as _StructureFactory
+create_surface = _StructureFactory.surface
+create_ase_bulk = _StructureFactory.ase_bulk
+create_structure = _StructureFactory.crystal
+
+
 
 # Make classes available for new pyiron version
 JOB_CLASS_DICT["ART"] = "pyiron.interactive.activation_relaxation_technique"

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -1023,7 +1023,7 @@ class Atoms(ASEAtoms):
     def analyse_ovito_voronoi_volume(self):
         warnings.warn(
             "analyse_ovito_voronoi_volume() is available for backwards compatiblity, " +
-            "please use analyse_ovito_voronoi_volume()",
+            "please use analyse_pyscal_voronoi_volume()",
             DeprecationWarning
         )
         return self.analyse_pyscal_voronoi_volume()
@@ -2018,10 +2018,10 @@ class Atoms(ASEAtoms):
         """
         warnings.warn(
             "This function doesn't account for periodic boundary conditions. Call "
-            "`analyse_ovito_voronoi_volume` instead. This is what will now be returned.",
+            "`analyse_pyscal_voronoi_volume` instead. This is what will now be returned.",
             DeprecationWarning,
         )
-        return self.analyse_ovito_voronoi_volume()
+        return self.analyse_pyscal_voronoi_volume()
 
     def find_mic(self, v, vectors=True):
         """

--- a/pyiron/atomistics/structure/factory.py
+++ b/pyiron/atomistics/structure/factory.py
@@ -123,7 +123,7 @@ class StructureFactory:
             return None
 
     @staticmethod
-    def hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
+    def surface_hkl(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
         """
         Use ase.build.surface to build a surface with surface normal (hkl).
 

--- a/pyiron/atomistics/structure/factory.py
+++ b/pyiron/atomistics/structure/factory.py
@@ -151,7 +151,7 @@ class StructureFactory:
         return ase_to_pyiron(surface)
 
     @staticmethod
-    def structure(element, bravais_basis, lattice_constant):
+    def crystal(element, bravais_basis, lattice_constant):
         """
         Create a crystal structure using pyiron's native crystal structure generator
 

--- a/pyiron/atomistics/structure/factory.py
+++ b/pyiron/atomistics/structure/factory.py
@@ -52,6 +52,7 @@ class StructureFactory:
         """
         Returns a ASE's read result, wrapped as a `pyiron.atomstic.structure.atoms.Atoms` object.
 
+        ase.io.read docstring:
         """
         return ase_to_pyiron(read(*args, **kwargs))
     ase_read.__doc__ += read.__doc__

--- a/pyiron/atomistics/structure/factory.py
+++ b/pyiron/atomistics/structure/factory.py
@@ -47,7 +47,7 @@ __date__ = "May 1, 2020"
 s = Settings()
 
 
-class StructureGenerator:
+class StructureFactory:
     def ase_read(self, *args, **kwargs):
         """
         Returns a ASE's read result, wrapped as a `pyiron.atomstic.structure.atoms.Atoms` object.

--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -57,7 +57,7 @@ class StructureGenerator:
     ase_read.__doc__ += read.__doc__
 
     @staticmethod
-    def create_surface(
+    def surface(
         element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=True, **kwargs
     ):
         """
@@ -123,7 +123,7 @@ class StructureGenerator:
             return None
 
     @staticmethod
-    def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
+    def hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
         """
         Use ase.build.surface to build a surface with surface normal (hkl).
 
@@ -151,7 +151,7 @@ class StructureGenerator:
         return ase_to_pyiron(surface)
 
     @staticmethod
-    def create_structure(element, bravais_basis, lattice_constant):
+    def structure(element, bravais_basis, lattice_constant):
         """
         Create a crystal structure using pyiron's native crystal structure generator
 
@@ -170,7 +170,7 @@ class StructureGenerator:
         )
 
     @staticmethod
-    def create_ase_bulk(
+    def ase_bulk(
         name,
         crystalstructure=None,
         a=None,
@@ -210,7 +210,7 @@ class StructureGenerator:
         ))
 
     @staticmethod
-    def create_atoms(
+    def atoms(
             symbols=None,
             positions=None,
             numbers=None,
@@ -286,7 +286,7 @@ class StructureGenerator:
         )
 
     @staticmethod
-    def create_element(parent_element, new_element_name=None, spin=None, potential_file=None):
+    def element(parent_element, new_element_name=None, spin=None, potential_file=None):
         """
 
         Args:

--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -25,6 +25,7 @@ from ase.build import (
         root_surface_analysis,
         surface as ase_surf,
     )
+from ase.io import read
 import numpy as np
 from pyiron.atomistics.structure.pyironase import publication as publication_ase
 from pyiron.atomistics.structure.atoms import CrystalStructure, ase_to_pyiron
@@ -45,156 +46,158 @@ __date__ = "May 1, 2020"
 s = Settings()
 
 
-def create_surface(
-    element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=True, **kwargs
-):
-    """
-    Generate a surface based on the ase.build.surface module.
+class StructureGenerator:
+    @staticmethod
+    def create_surface(
+        element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=True, **kwargs
+    ):
+        """
+        Generate a surface based on the ase.build.surface module.
 
-    Args:
-        element (str): Element name
-        surface_type (str): The string specifying the surface type generators available through ase (fcc111,
-        hcp0001 etc.)
-        size (tuple): Size of the surface
-        vacuum (float): Length of vacuum layer added to the surface along the z direction
-        center (bool): Tells if the surface layers have to be at the center or at one end along the z-direction
-        pbc (list/numpy.ndarray): List of booleans specifying the periodic boundary conditions along all three
-                                  directions.
-        **kwargs: Additional, arguments you would normally pass to the structure generator like 'a', 'b',
-        'orthogonal' etc.
+        Args:
+            element (str): Element name
+            surface_type (str): The string specifying the surface type generators available through ase (fcc111,
+            hcp0001 etc.)
+            size (tuple): Size of the surface
+            vacuum (float): Length of vacuum layer added to the surface along the z direction
+            center (bool): Tells if the surface layers have to be at the center or at one end along the z-direction
+            pbc (list/numpy.ndarray): List of booleans specifying the periodic boundary conditions along all three
+                                      directions.
+            **kwargs: Additional, arguments you would normally pass to the structure generator like 'a', 'b',
+            'orthogonal' etc.
 
-    Returns:
-        pyiron.atomistics.structure.atoms.Atoms instance: Required surface
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms instance: Required surface
 
-    """
-    # https://gitlab.com/ase/ase/blob/master/ase/lattice/surface.py
-    if pbc is None:
-        pbc = True
-    s.publication_add(publication_ase())
-    for surface_class in [
-        add_adsorbate,
-        add_vacuum,
-        bcc100,
-        bcc110,
-        bcc111,
-        diamond100,
-        diamond111,
-        fcc100,
-        fcc110,
-        fcc111,
-        fcc211,
-        hcp0001,
-        hcp10m10,
-        mx2,
-        hcp0001_root,
-        fcc111_root,
-        bcc111_root,
-        root_surface,
-        root_surface_analysis,
-        ase_surf,
-    ]:
-        if surface_type == surface_class.__name__:
-            surface_type = surface_class
-            break
-    if isinstance(surface_type, types.FunctionType):
-        if center:
-            surface = surface_type(
-                symbol=element, size=size, vacuum=vacuum, **kwargs
-            )
+        """
+        # https://gitlab.com/ase/ase/blob/master/ase/lattice/surface.py
+        if pbc is None:
+            pbc = True
+        s.publication_add(publication_ase())
+        for surface_class in [
+            add_adsorbate,
+            add_vacuum,
+            bcc100,
+            bcc110,
+            bcc111,
+            diamond100,
+            diamond111,
+            fcc100,
+            fcc110,
+            fcc111,
+            fcc211,
+            hcp0001,
+            hcp10m10,
+            mx2,
+            hcp0001_root,
+            fcc111_root,
+            bcc111_root,
+            root_surface,
+            root_surface_analysis,
+            ase_surf,
+        ]:
+            if surface_type == surface_class.__name__:
+                surface_type = surface_class
+                break
+        if isinstance(surface_type, types.FunctionType):
+            if center:
+                surface = surface_type(
+                    symbol=element, size=size, vacuum=vacuum, **kwargs
+                )
+            else:
+                surface = surface_type(symbol=element, size=size, **kwargs)
+                z_max = np.max(surface.positions[:, 2])
+                surface.cell[2, 2] = z_max + vacuum
+            surface.pbc = pbc
+            return ase_to_pyiron(surface)
         else:
-            surface = surface_type(symbol=element, size=size, **kwargs)
-            z_max = np.max(surface.positions[:, 2])
-            surface.cell[2, 2] = z_max + vacuum
+            return None
+
+    @staticmethod
+    def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
+        """
+        Use ase.build.surface to build a surface with surface normal (hkl).
+
+        Args:
+            lattice (pyiron.atomistics.structure.atoms.Atoms/str): bulk Atoms
+                instance or str, e.g. "Fe", from which to build the surface
+            hkl (list): miller indices of surface to be created
+            layers (int): # of atomic layers in the surface
+            vacuum (float): vacuum spacing
+            center (bool): shift all positions to center the surface
+                in the cell
+
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms instance: Required surface
+        """
+        # https://gitlab.com/ase/ase/blob/master/ase/lattice/surface.py
+        s.publication_add(publication_ase())
+
+        surface = ase_surf(lattice, hkl, layers)
+        z_max = np.max(surface.positions[:, 2])
+        surface.cell[2, 2] = z_max + vacuum
+        if center:
+            surface.positions += 0.5 * surface.cell[2] - [0, 0, z_max/2]
         surface.pbc = pbc
         return ase_to_pyiron(surface)
-    else:
-        return None
 
+    @staticmethod
+    def create_structure(element, bravais_basis, lattice_constant):
+        """
+        Create a crystal structure using pyiron's native crystal structure generator
 
-def create_hkl_surface(lattice, hkl, layers, vacuum=1.0, center=False, pbc=True):
-    """
-    Use ase.build.surface to build a surface with surface normal (hkl).
+        Args:
+            element (str): Element name
+            bravais_basis (str): Basis type
+            lattice_constant (float/list): Lattice constants
 
-    Args:
-        lattice (pyiron.atomistics.structure.atoms.Atoms/str): bulk Atoms
-            instance or str, e.g. "Fe", from which to build the surface
-        hkl (list): miller indices of surface to be created
-        layers (int): # of atomic layers in the surface
-        vacuum (float): vacuum spacing
-        center (bool): shift all positions to center the surface
-            in the cell
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
 
-    Returns:
-        pyiron.atomistics.structure.atoms.Atoms instance: Required surface
-    """
-    # https://gitlab.com/ase/ase/blob/master/ase/lattice/surface.py
-    s.publication_add(publication_ase())
+        """
+        return CrystalStructure(
+            element=element,
+            bravais_basis=bravais_basis,
+            lattice_constants=[lattice_constant],
+        )
 
-    surface = ase_surf(lattice, hkl, layers)
-    z_max = np.max(surface.positions[:, 2])
-    surface.cell[2, 2] = z_max + vacuum
-    if center:
-        surface.positions += 0.5 * surface.cell[2] - [0, 0, z_max/2]
-    surface.pbc = pbc
-    return ase_to_pyiron(surface)
+    @staticmethod
+    def create_ase_bulk(
+        name,
+        crystalstructure=None,
+        a=None,
+        c=None,
+        covera=None,
+        u=None,
+        orthorhombic=False,
+        cubic=False,
+    ):
+        """
+        Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
+        provided.
 
+        name (str): Chemical symbol or symbols as in 'MgO' or 'NaCl'.
+        crystalstructure (str): Must be one of sc, fcc, bcc, hcp, diamond, zincblende,
+                                rocksalt, cesiumchloride, fluorite or wurtzite.
+        a (float): Lattice constant.
+        c (float): Lattice constant.
+        c_over_a (float): c/a ratio used for hcp.  Default is ideal ratio: sqrt(8/3).
+        u (float): Internal coordinate for Wurtzite structure.
+        orthorhombic (bool): Construct orthorhombic unit cell instead of primitive cell which is the default.
+        cubic (bool): Construct cubic unit cell if possible.
 
-def create_structure(element, bravais_basis, lattice_constant):
-    """
-    Create a crystal structure using pyiron's native crystal structure generator
+        Returns:
 
-    Args:
-        element (str): Element name
-        bravais_basis (str): Basis type
-        lattice_constant (float/list): Lattice constants
-
-    Returns:
-        pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
-
-    """
-    return CrystalStructure(
-        element=element,
-        bravais_basis=bravais_basis,
-        lattice_constants=[lattice_constant],
-    )
-
-
-def create_ase_bulk(
-    name,
-    crystalstructure=None,
-    a=None,
-    c=None,
-    covera=None,
-    u=None,
-    orthorhombic=False,
-    cubic=False,
-):
-    """
-    Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
-    provided.
-
-    name (str): Chemical symbol or symbols as in 'MgO' or 'NaCl'.
-    crystalstructure (str): Must be one of sc, fcc, bcc, hcp, diamond, zincblende,
-                            rocksalt, cesiumchloride, fluorite or wurtzite.
-    a (float): Lattice constant.
-    c (float): Lattice constant.
-    c_over_a (float): c/a ratio used for hcp.  Default is ideal ratio: sqrt(8/3).
-    u (float): Internal coordinate for Wurtzite structure.
-    orthorhombic (bool): Construct orthorhombic unit cell instead of primitive cell which is the default.
-    cubic (bool): Construct cubic unit cell if possible.
-
-    Returns:
-
-        pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
-    """
-    s.publication_add(publication_ase())
-    return ase_to_pyiron(bulk(
-        name=name,
-        crystalstructure=crystalstructure,
-        a=a,
-        c=c,
-        covera=covera,
-        u=u,
-        orthorhombic=orthorhombic,
-        cubic=cubic,
-    ))
+            pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
+        """
+        s.publication_add(publication_ase())
+        return ase_to_pyiron(bulk(
+            name=name,
+            crystalstructure=crystalstructure,
+            a=a,
+            c=c,
+            covera=covera,
+            u=u,
+            orthorhombic=orthorhombic,
+            cubic=cubic,
+        ))

--- a/pyiron/atomistics/structure/generator.py
+++ b/pyiron/atomistics/structure/generator.py
@@ -48,6 +48,14 @@ s = Settings()
 
 
 class StructureGenerator:
+    def ase_read(self, *args, **kwargs):
+        """
+        Returns a ASE's read result, wrapped as a `pyiron.atomstic.structure.atoms.Atoms` object.
+
+        """
+        return ase_to_pyiron(read(*args, **kwargs))
+    ase_read.__doc__ += read.__doc__
+
     @staticmethod
     def create_surface(
         element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=True, **kwargs

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -415,6 +415,7 @@ class LammpsControl(GenericParameters):
         tloop=None,
         initial_temperature=None,
         langevin=False,
+        drag=None,
         delta_temp=None,
         delta_press=None,
         job_name="",
@@ -454,6 +455,9 @@ class LammpsControl(GenericParameters):
                                                be used). If any other number is given, this value is going to be used
                                                for the initial temperature.
             langevin (bool): (True or False) Activate Langevin dynamics
+            drag (float): Drag to apply. Note: Using this flag will destroy your thermodynamics and you will no longer
+                acheive the NVT/NPT/NPH/NVE ensemble averages you would otherwise expect. (Default is None, no
+                additional drag (Langevin drag still applied in case of a Langevin thermostat).)
             delta_temp (float): Thermostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
             delta_press (float): Barostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
             job_name (str): Job name of the job to generate a unique random seed.
@@ -574,6 +578,9 @@ class LammpsControl(GenericParameters):
         if tloop is not None:
             fix_ensemble_str += " tloop " + str(tloop)
 
+        if drag is not None:
+            fix_ensemble_str += " drag " + str(drag)
+
         self.remove_keys(["minimize"])
         self.modify(
             fix___ensemble=fix_ensemble_str,
@@ -619,6 +626,7 @@ class LammpsControl(GenericParameters):
         seed=None,
         initial_temperature=None,
         langevin=False,
+        drag=None,
         job_name="",
         rotation_matrix=None
     ):
@@ -672,6 +680,7 @@ class LammpsControl(GenericParameters):
             tloop=None,
             initial_temperature=initial_temperature,
             langevin=langevin,
+            drag=drag,
             job_name=job_name,
             rotation_matrix=rotation_matrix
         )

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -415,7 +415,6 @@ class LammpsControl(GenericParameters):
         tloop=None,
         initial_temperature=None,
         langevin=False,
-        drag=None,
         delta_temp=None,
         delta_press=None,
         job_name="",
@@ -455,9 +454,6 @@ class LammpsControl(GenericParameters):
                                                be used). If any other number is given, this value is going to be used
                                                for the initial temperature.
             langevin (bool): (True or False) Activate Langevin dynamics
-            drag (float): Drag to apply. Note: Using this flag will destroy your thermodynamics and you will no longer
-                acheive the NVT/NPT/NPH/NVE ensemble averages you would otherwise expect. (Default is None, no
-                additional drag (Langevin drag still applied in case of a Langevin thermostat).)
             delta_temp (float): Thermostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
             delta_press (float): Barostat timescale, but in your Lammps time units, whatever those are. (DEPRECATED.)
             job_name (str): Job name of the job to generate a unique random seed.
@@ -578,9 +574,6 @@ class LammpsControl(GenericParameters):
         if tloop is not None:
             fix_ensemble_str += " tloop " + str(tloop)
 
-        if drag is not None:
-            fix_ensemble_str += " drag " + str(drag)
-
         self.remove_keys(["minimize"])
         self.modify(
             fix___ensemble=fix_ensemble_str,
@@ -626,7 +619,6 @@ class LammpsControl(GenericParameters):
         seed=None,
         initial_temperature=None,
         langevin=False,
-        drag=None,
         job_name="",
         rotation_matrix=None
     ):
@@ -680,7 +672,6 @@ class LammpsControl(GenericParameters):
             tloop=None,
             initial_temperature=initial_temperature,
             langevin=langevin,
-            drag=drag,
             job_name=job_name,
             rotation_matrix=rotation_matrix
         )

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -449,7 +449,7 @@ class Project(ProjectCore):
             cubic=False,
     ):
         """
-        Deprecated as of v.0.3.12, please use `Project.structure.create_ase_bulk`.
+        Deprecated as of v.0.3, please use `Project.create.structure.ase_bulk`.
 
         Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
         provided.
@@ -469,7 +469,7 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
         """
         warnings.warn(
-            "Project.create_ase_bulk is deprecated as of v0.3.12. Please use Project.structure.create_ase_bulk.",
+            "Project.create_ase_bulk is deprecated as of v0.3. Please use Project.create.structure.ase_bulk.",
             DeprecationWarning
         )
         return self.create.structure.ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c,
@@ -477,7 +477,7 @@ class Project(ProjectCore):
 
     def create_structure(self, element, bravais_basis, lattice_constant):
         """
-        Deprecated as of v.0.3.12, please use `Project.structure.create_structure`.
+        Deprecated as of v.0.3, please use `Project.create.structure.structure`.
 
         Create a crystal structure using pyiron's native crystal structure generator
 
@@ -491,7 +491,7 @@ class Project(ProjectCore):
 
         """
         warnings.warn(
-            "Project.create_structure is deprecated as of v0.3.12. Please use Project.structure.create_structure.",
+            "Project.create_structure is deprecated as of v0.3. Please use Project.create.structure.structure.",
             DeprecationWarning
         )
         return self.create.structure.structure(element=element, bravais_basis=bravais_basis,
@@ -501,7 +501,7 @@ class Project(ProjectCore):
             self, element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=None, **kwargs
     ):
         """
-        Deprecated as of v.0.3.12, please use `Project.structure.create_surface`.
+        Deprecated as of v.0.3, please use `Project.create.structure.surface`.
 
         Generate a surface based on the ase.build.surface module.
 
@@ -522,7 +522,7 @@ class Project(ProjectCore):
 
         """
         warnings.warn(
-            "Project.create_surface is deprecated as of v0.3.12. Please use Project.structure.create_surface.",
+            "Project.create_surface is deprecated as of v0.3. Please use Project.create.structure.surface.",
             DeprecationWarning
         )
         return self.create.structure.surface(element=element, surface_type=surface_type, size=size,
@@ -552,7 +552,7 @@ class Project(ProjectCore):
             **qwargs
     ):
         """
-        Deprecated as of v.0.3.12, please use `Project.structure.create_atoms`.
+        Deprecated as of v.0.3, please use `Project.create.structure.atoms`.
 
         Creates a atomistics.structure.atoms.Atoms instance.
 
@@ -582,7 +582,7 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms: The required structure instance
         """
         warnings.warn(
-            "Project.create_atoms is deprecated as of v0.3.12. Please use Project.structure.create_atoms.",
+            "Project.create_atoms is deprecated as of v0.3. Please use Project.create.structure.atoms.",
             DeprecationWarning
         )
         return self.create.structure.atoms(
@@ -610,7 +610,7 @@ class Project(ProjectCore):
 
     def create_element(self, parent_element, new_element_name=None, spin=None, potential_file=None):
         """
-        Deprecated as of v.0.3.12, please use `Project.structure.create_element`.
+        Deprecated as of v.0.3, please use `Project.create.structure.element`.
 
         Args:
             parent_element (str, int): The parent element eq. "N", "O", "Mg" etc.
@@ -622,7 +622,7 @@ class Project(ProjectCore):
             atomistics.structure.periodic_table.ChemicalElement instance
         """
         warnings.warn(
-            "Project.create_element is deprecated as of v0.3.12. Please use Project.structure.create_element.",
+            "Project.create_element is deprecated as of v0.3. Please use Project.create.structure.element.",
             DeprecationWarning
         )
         return self.create.structure.element(

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -449,8 +449,6 @@ class Project(ProjectCore):
             cubic=False,
     ):
         """
-        Deprecated as of v.0.3, please use `Project.create.structure.ase_bulk`.
-
         Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
         provided.
 
@@ -468,17 +466,15 @@ class Project(ProjectCore):
 
             pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
         """
-        warnings.warn(
-            "Project.create_ase_bulk is deprecated as of v0.3. Please use Project.create.structure.ase_bulk.",
-            DeprecationWarning
-        )
+        # warnings.warn(
+        #     "Project.create_ase_bulk is deprecated as of v0.3. Please use Project.create.structure.ase_bulk.",
+        #     DeprecationWarning
+        # )
         return self.create.structure.ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c,
                                               covera=covera, u=u, orthorhombic=orthorhombic, cubic=cubic)
 
     def create_structure(self, element, bravais_basis, lattice_constant):
         """
-        Deprecated as of v.0.3, please use `Project.create.structure.structure`.
-
         Create a crystal structure using pyiron's native crystal structure generator
 
         Args:
@@ -490,10 +486,10 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
 
         """
-        warnings.warn(
-            "Project.create_structure is deprecated as of v0.3. Please use Project.create.structure.structure.",
-            DeprecationWarning
-        )
+        # warnings.warn(
+        #     "Project.create_structure is deprecated as of v0.3. Please use Project.create.structure.structure.",
+        #     DeprecationWarning
+        # )
         return self.create.structure.structure(element=element, bravais_basis=bravais_basis,
                                                lattice_constant=lattice_constant)
 
@@ -501,8 +497,6 @@ class Project(ProjectCore):
             self, element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=None, **kwargs
     ):
         """
-        Deprecated as of v.0.3, please use `Project.create.structure.surface`.
-
         Generate a surface based on the ase.build.surface module.
 
         Args:
@@ -521,10 +515,10 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms instance: Required surface
 
         """
-        warnings.warn(
-            "Project.create_surface is deprecated as of v0.3. Please use Project.create.structure.surface.",
-            DeprecationWarning
-        )
+        # warnings.warn(
+        #     "Project.create_surface is deprecated as of v0.3. Please use Project.create.structure.surface.",
+        #     DeprecationWarning
+        # )
         return self.create.structure.surface(element=element, surface_type=surface_type, size=size,
                                              vacuum=vacuum, center=center, pbc=pbc, **kwargs)
 
@@ -552,8 +546,6 @@ class Project(ProjectCore):
             **qwargs
     ):
         """
-        Deprecated as of v.0.3, please use `Project.create.structure.atoms`.
-
         Creates a atomistics.structure.atoms.Atoms instance.
 
         Args:
@@ -581,10 +573,10 @@ class Project(ProjectCore):
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: The required structure instance
         """
-        warnings.warn(
-            "Project.create_atoms is deprecated as of v0.3. Please use Project.create.structure.atoms.",
-            DeprecationWarning
-        )
+        # warnings.warn(
+        #     "Project.create_atoms is deprecated as of v0.3. Please use Project.create.structure.atoms.",
+        #     DeprecationWarning
+        # )
         return self.create.structure.atoms(
             symbols=symbols,
             positions=positions,
@@ -610,8 +602,6 @@ class Project(ProjectCore):
 
     def create_element(self, parent_element, new_element_name=None, spin=None, potential_file=None):
         """
-        Deprecated as of v.0.3, please use `Project.create.structure.element`.
-
         Args:
             parent_element (str, int): The parent element eq. "N", "O", "Mg" etc.
             new_element_name (str): The name of the new parent element (can be arbitrary)
@@ -621,10 +611,10 @@ class Project(ProjectCore):
         Returns:
             atomistics.structure.periodic_table.ChemicalElement instance
         """
-        warnings.warn(
-            "Project.create_element is deprecated as of v0.3. Please use Project.create.structure.element.",
-            DeprecationWarning
-        )
+        # warnings.warn(
+        #     "Project.create_element is deprecated as of v0.3. Please use Project.create.structure.element.",
+        #     DeprecationWarning
+        # )
         return self.create.structure.element(
             parent_element=parent_element,
             new_element_name=new_element_name,

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -114,6 +114,9 @@ class Project(ProjectCore):
         )
         self.job_type = JobTypeChoice()
         self.object_type = ObjectTypeChoice()
+        self._creator = Creator(self)
+        # TODO: instead of re-initialzing, auto-update pyiron_base creator with factories, like we update job class
+        #  creation
 
     def create_job(self, job_type, job_name, delete_existing_job=False):
         """

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -18,7 +18,7 @@ from pyiron.lammps.potential import LammpsPotentialFile
 from pyiron.vasp.potential import VaspPotential
 import pyiron.atomistics.structure.pyironase as ase
 from pyiron.atomistics.structure.atoms import Atoms
-from pyiron.atomistics.structure.generator import create_surface, create_ase_bulk, create_structure
+from pyiron.atomistics.structure.generator import StructureGenerator
 from pyiron.atomistics.master.parallel import pipe
 
 
@@ -409,7 +409,7 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
 
         """
-        return create_structure(element=element, bravais_basis=bravais_basis, lattice_constant=lattice_constant)
+        return StructureGenerator.create_structure(element=element, bravais_basis=bravais_basis, lattice_constant=lattice_constant)
 
     @staticmethod
     def create_ase_bulk(
@@ -440,7 +440,7 @@ class Project(ProjectCore):
 
             pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
         """
-        return create_ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c, covera=covera, u=u,
+        return StructureGenerator.create_ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c, covera=covera, u=u,
                                orthorhombic=orthorhombic, cubic=cubic)
 
     @staticmethod
@@ -543,7 +543,7 @@ class Project(ProjectCore):
             pyiron.atomistics.structure.atoms.Atoms instance: Required surface
 
         """
-        return create_surface(element=element, surface_type=surface_type,
+        return StructureGenerator.create_surface(element=element, surface_type=surface_type,
                               size=size, vacuum=vacuum, center=center, pbc=pbc, **kwargs)
 
     @staticmethod

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -19,7 +19,7 @@ from pyiron.lammps.potential import LammpsPotentialFile
 from pyiron.vasp.potential import VaspPotential
 import pyiron.atomistics.structure.pyironase as ase
 from pyiron.atomistics.structure.atoms import Atoms
-from pyiron.atomistics.structure.generator import StructureGenerator
+from pyiron.atomistics.structure.factory import StructureFactory
 from pyiron.atomistics.master.parallel import pipe
 
 
@@ -632,4 +632,4 @@ class Project(ProjectCore):
 class _ProjectObjectCreator:
 
     def __init__(self):
-        self.structure = StructureGenerator()
+        self.structure = StructureFactory()

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -114,7 +114,7 @@ class Project(ProjectCore):
         )
         self.job_type = JobTypeChoice()
         self.object_type = ObjectTypeChoice()
-        self.structure = StructureGenerator()
+        self.create = _ProjectObjectCreator()
 
     def create_job(self, job_type, job_name, delete_existing_job=False):
         """
@@ -397,8 +397,6 @@ class Project(ProjectCore):
         ):
             self.import_single_calculation(path, rel_path=rel_path, job_type="KMC", copy_raw_files=copy_raw_files)
 
-
-
     @staticmethod
     def inspect_periodic_table():
         return PeriodicTable()
@@ -470,8 +468,8 @@ class Project(ProjectCore):
             "Project.create_ase_bulk is deprecated as of v0.3.12. Please use Project.structure.create_ase_bulk.",
             DeprecationWarning
         )
-        return self.structure.create_ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c, covera=covera,
-                                              u=u, orthorhombic=orthorhombic, cubic=cubic)
+        return self.create.structure.ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c,
+                                              covera=covera, u=u, orthorhombic=orthorhombic, cubic=cubic)
 
     def create_structure(self, element, bravais_basis, lattice_constant):
         """
@@ -492,7 +490,7 @@ class Project(ProjectCore):
             "Project.create_structure is deprecated as of v0.3.12. Please use Project.structure.create_structure.",
             DeprecationWarning
         )
-        return self.structure.create_structure(element=element, bravais_basis=bravais_basis,
+        return self.create.structure.structure(element=element, bravais_basis=bravais_basis,
                                                lattice_constant=lattice_constant)
 
     def create_surface(
@@ -523,8 +521,8 @@ class Project(ProjectCore):
             "Project.create_surface is deprecated as of v0.3.12. Please use Project.structure.create_surface.",
             DeprecationWarning
         )
-        return self.structure.create_surface(element=element, surface_type=surface_type, size=size, vacuum=vacuum,
-                                             center=center, pbc=pbc, **kwargs)
+        return self.create.structure.surface(element=element, surface_type=surface_type, size=size,
+                                             vacuum=vacuum, center=center, pbc=pbc, **kwargs)
 
     def create_atoms(
             self,
@@ -583,7 +581,7 @@ class Project(ProjectCore):
             "Project.create_atoms is deprecated as of v0.3.12. Please use Project.structure.create_atoms.",
             DeprecationWarning
         )
-        return self.structure.create_atoms(
+        return self.create.structure.atoms(
             symbols=symbols,
             positions=positions,
             numbers=numbers,
@@ -623,9 +621,15 @@ class Project(ProjectCore):
             "Project.create_element is deprecated as of v0.3.12. Please use Project.structure.create_element.",
             DeprecationWarning
         )
-        return self.structure.create_element(
+        return self.create.structure.element(
             parent_element=parent_element,
             new_element_name=new_element_name,
             spin=spin,
             potential_file=potential_file
         )
+
+
+class _ProjectObjectCreator:
+
+    def __init__(self):
+        self.structure = StructureGenerator()

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 import os
 import posixpath
-import warnings
+# import warnings
 from string import punctuation
 from shutil import copyfile
 from pyiron_base import Settings, ProjectHDFio, JobType, JobTypeChoice, Project as ProjectCore, Creator as CreatorCore

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -397,82 +397,7 @@ class Project(ProjectCore):
         ):
             self.import_single_calculation(path, rel_path=rel_path, job_type="KMC", copy_raw_files=copy_raw_files)
 
-    @staticmethod
-    def create_atoms(
-        symbols=None,
-        positions=None,
-        numbers=None,
-        tags=None,
-        momenta=None,
-        masses=None,
-        magmoms=None,
-        charges=None,
-        scaled_positions=None,
-        cell=None,
-        pbc=None,
-        celldisp=None,
-        constraint=None,
-        calculator=None,
-        info=None,
-        indices=None,
-        elements=None,
-        dimension=None,
-        species=None,
-        **qwargs
-    ):
-        """
-        Creates a atomistics.structure.atoms.Atoms instance.
 
-        Args:
-            elements (list/numpy.ndarray): List of strings containing the elements or a list of
-                                atomistics.structure.periodic_table.ChemicalElement instances
-            numbers (list/numpy.ndarray): List of atomic numbers of elements
-            symbols (list/numpy.ndarray): List of chemical symbols
-            positions (list/numpy.ndarray): List of positions
-            scaled_positions (list/numpy.ndarray): List of scaled positions (relative coordinates)
-            pbc (boolean): Tells if periodic boundary conditions should be applied
-            cell (list/numpy.ndarray): A 3x3 array representing the lattice vectors of the structure
-            momenta (list/numpy.ndarray): List of momentum values
-            tags (list/numpy.ndarray): A list of tags
-            masses (list/numpy.ndarray): A list of masses
-            magmoms (list/numpy.ndarray): A list of magnetic moments
-            charges (list/numpy.ndarray): A list of point charges
-            celldisp:
-            constraint (list/numpy.ndarray): A list of constraints
-            calculator: ASE calculator
-            info (list/str): ASE compatibility
-            indices (list/numpy.ndarray): The list of species indices
-            dimension (int): Dimension of the structure
-            species (list): List of species
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required structure instance
-
-        """
-        if pbc is None:
-            pbc = True
-        return Atoms(
-            symbols=symbols,
-            positions=positions,
-            numbers=numbers,
-            tags=tags,
-            momenta=momenta,
-            masses=masses,
-            magmoms=magmoms,
-            charges=charges,
-            scaled_positions=scaled_positions,
-            cell=cell,
-            pbc=pbc,
-            celldisp=celldisp,
-            constraint=constraint,
-            calculator=calculator,
-            info=info,
-            indices=indices,
-            elements=elements,
-            dimension=dimension,
-            species=species,
-            **qwargs
-        )
 
     @staticmethod
     def inspect_periodic_table():
@@ -485,55 +410,6 @@ class Project(ProjectCore):
     @staticmethod
     def inspect_pseudo_potentials():
         return VaspPotential()
-
-    @staticmethod
-    def create_element(
-        parent_element, new_element_name=None, spin=None, potential_file=None
-    ):
-        """
-
-        Args:
-            parent_element (str, int): The parent element eq. "N", "O", "Mg" etc.
-            new_element_name (str): The name of the new parent element (can be arbitrary)
-            spin (float): Value of the magnetic moment (with sign)
-            potential_file (str): Location of the new potential file if necessary
-
-        Returns:
-            atomistics.structure.periodic_table.ChemicalElement instance
-        """
-        periodic_table = PeriodicTable()
-        if new_element_name is None:
-            if spin is not None:
-                new_element_name = (
-                    parent_element + "_spin_" + str(spin).replace(".", "_")
-                )
-            else:
-                new_element_name = parent_element + "_1"
-        if potential_file is not None:
-            if spin is not None:
-                periodic_table.add_element(
-                    parent_element=parent_element,
-                    new_element=new_element_name,
-                    spin=str(spin),
-                    pseudo_potcar_file=potential_file,
-                )
-            else:
-                periodic_table.add_element(
-                    parent_element=parent_element,
-                    new_element=new_element_name,
-                    pseudo_potcar_file=potential_file,
-                )
-        elif spin is not None:
-            periodic_table.add_element(
-                parent_element=parent_element,
-                new_element=new_element_name,
-                spin=str(spin),
-            )
-        else:
-            periodic_table.add_element(
-                parent_element=parent_element, new_element=new_element_name
-            )
-        return periodic_table.element(new_element_name)
 
     # Graphical user interfaces
     def gui(self):
@@ -649,3 +525,107 @@ class Project(ProjectCore):
         )
         return self.structure.create_surface(element=element, surface_type=surface_type, size=size, vacuum=vacuum,
                                              center=center, pbc=pbc, **kwargs)
+
+    def create_atoms(
+            self,
+            symbols=None,
+            positions=None,
+            numbers=None,
+            tags=None,
+            momenta=None,
+            masses=None,
+            magmoms=None,
+            charges=None,
+            scaled_positions=None,
+            cell=None,
+            pbc=None,
+            celldisp=None,
+            constraint=None,
+            calculator=None,
+            info=None,
+            indices=None,
+            elements=None,
+            dimension=None,
+            species=None,
+            **qwargs
+    ):
+        """
+        Deprecated as of v.0.3.12, please use `Project.structure.create_atoms`.
+
+        Creates a atomistics.structure.atoms.Atoms instance.
+
+        Args:
+            elements (list/numpy.ndarray): List of strings containing the elements or a list of
+                                atomistics.structure.periodic_table.ChemicalElement instances
+            numbers (list/numpy.ndarray): List of atomic numbers of elements
+            symbols (list/numpy.ndarray): List of chemical symbols
+            positions (list/numpy.ndarray): List of positions
+            scaled_positions (list/numpy.ndarray): List of scaled positions (relative coordinates)
+            pbc (boolean): Tells if periodic boundary conditions should be applied
+            cell (list/numpy.ndarray): A 3x3 array representing the lattice vectors of the structure
+            momenta (list/numpy.ndarray): List of momentum values
+            tags (list/numpy.ndarray): A list of tags
+            masses (list/numpy.ndarray): A list of masses
+            magmoms (list/numpy.ndarray): A list of magnetic moments
+            charges (list/numpy.ndarray): A list of point charges
+            celldisp:
+            constraint (list/numpy.ndarray): A list of constraints
+            calculator: ASE calculator
+            info (list/str): ASE compatibility
+            indices (list/numpy.ndarray): The list of species indices
+            dimension (int): Dimension of the structure
+            species (list): List of species
+
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms: The required structure instance
+        """
+        warnings.warn(
+            "Project.create_atoms is deprecated as of v0.3.12. Please use Project.structure.create_atoms.",
+            DeprecationWarning
+        )
+        return self.structure.create_atoms(
+            symbols=symbols,
+            positions=positions,
+            numbers=numbers,
+            tags=tags,
+            momenta=momenta,
+            masses=masses,
+            magmoms=magmoms,
+            charges=charges,
+            scaled_positions=scaled_positions,
+            cell=cell,
+            pbc=pbc,
+            celldisp=celldisp,
+            constraint=constraint,
+            calculator=calculator,
+            info=info,
+            indices=indices,
+            elements=elements,
+            dimension=dimension,
+            species=species,
+            **qwargs
+        )
+
+    def create_element(self, parent_element, new_element_name=None, spin=None, potential_file=None):
+        """
+        Deprecated as of v.0.3.12, please use `Project.structure.create_element`.
+
+        Args:
+            parent_element (str, int): The parent element eq. "N", "O", "Mg" etc.
+            new_element_name (str): The name of the new parent element (can be arbitrary)
+            spin (float): Value of the magnetic moment (with sign)
+            potential_file (str): Location of the new potential file if necessary
+
+        Returns:
+            atomistics.structure.periodic_table.ChemicalElement instance
+        """
+        warnings.warn(
+            "Project.create_element is deprecated as of v0.3.12. Please use Project.structure.create_element.",
+            DeprecationWarning
+        )
+        return self.structure.create_element(
+            parent_element=parent_element,
+            new_element_name=new_element_name,
+            spin=spin,
+            potential_file=potential_file
+        )

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -168,7 +168,16 @@ class Project(ProjectCore):
         Returns:
             GenericJob: job object depending on the job_type selected
         """
-        return super().create_job(job_type=job_type, job_name=job_name, delete_existing_job=delete_existing_job)
+        job = JobType(
+            job_type,
+            project=ProjectHDFio(project=self.copy(), file_name=job_name),
+            job_name=job_name,
+            job_class_dict=self.job_type.job_class_dict,
+            delete_existing_job=delete_existing_job,
+        )
+        if self.user is not None:
+            job.user = self.user
+        return job
 
     @staticmethod
     def create_object(object_type):

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -114,7 +114,11 @@ class Project(ProjectCore):
         )
         self.job_type = JobTypeChoice()
         self.object_type = ObjectTypeChoice()
-        self.create = _ProjectObjectCreator()
+        self._create = _Creator()
+
+    @property
+    def create(self):
+        return self._create
 
     def create_job(self, job_type, job_name, delete_existing_job=False):
         """
@@ -629,7 +633,11 @@ class Project(ProjectCore):
         )
 
 
-class _ProjectObjectCreator:
+class _Creator:
 
     def __init__(self):
-        self.structure = StructureFactory()
+        self._structure = StructureFactory()
+
+    @property
+    def structure(self):
+        return self._structure

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -114,11 +114,6 @@ class Project(ProjectCore):
         )
         self.job_type = JobTypeChoice()
         self.object_type = ObjectTypeChoice()
-        self._create = _Creator()
-
-    @property
-    def create(self):
-        return self._create
 
     def create_job(self, job_type, job_name, delete_existing_job=False):
         """

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -165,16 +165,7 @@ class Project(ProjectCore):
         Returns:
             GenericJob: job object depending on the job_type selected
         """
-        job = JobType(
-            job_type,
-            project=ProjectHDFio(project=self.copy(), file_name=job_name),
-            job_name=job_name,
-            job_class_dict=self.job_type.job_class_dict,
-            delete_existing_job=delete_existing_job,
-        )
-        if self.user is not None:
-            job.user = self.user
-        return job
+        return super().create_job(job_type=job_type, job_name=job_name, delete_existing_job=delete_existing_job)
 
     @staticmethod
     def create_object(object_type):

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -8,7 +8,7 @@ import posixpath
 import warnings
 from string import punctuation
 from shutil import copyfile
-from pyiron_base import Settings, ProjectHDFio, JobType, JobTypeChoice, Project as ProjectCore
+from pyiron_base import Settings, ProjectHDFio, JobType, JobTypeChoice, Project as ProjectCore, Creator as CreatorCore
 try:
     from pyiron_base import ProjectGUI
 except (ImportError, TypeError, AttributeError):
@@ -618,9 +618,10 @@ class Project(ProjectCore):
         )
 
 
-class _Creator:
+class Creator(CreatorCore):
 
-    def __init__(self):
+    def __init__(self, project):
+        super().__init__(project)
         self._structure = StructureFactory()
 
     @property

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 import os
 import posixpath
+import warnings
 from string import punctuation
 from shutil import copyfile
 from pyiron_base import Settings, ProjectHDFio, JobType, JobTypeChoice, Project as ProjectCore
@@ -113,6 +114,7 @@ class Project(ProjectCore):
         )
         self.job_type = JobTypeChoice()
         self.object_type = ObjectTypeChoice()
+        self.structure = StructureGenerator()
 
     def create_job(self, job_type, job_name, delete_existing_job=False):
         """
@@ -396,54 +398,6 @@ class Project(ProjectCore):
             self.import_single_calculation(path, rel_path=rel_path, job_type="KMC", copy_raw_files=copy_raw_files)
 
     @staticmethod
-    def create_structure(element, bravais_basis, lattice_constant):
-        """
-        Create a crystal structure using pyiron's native crystal structure generator
-
-        Args:
-            element (str): Element name
-            bravais_basis (str): Basis type
-            lattice_constant (float/list): Lattice constants
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
-
-        """
-        return StructureGenerator.create_structure(element=element, bravais_basis=bravais_basis, lattice_constant=lattice_constant)
-
-    @staticmethod
-    def create_ase_bulk(
-        name,
-        crystalstructure=None,
-        a=None,
-        c=None,
-        covera=None,
-        u=None,
-        orthorhombic=False,
-        cubic=False,
-    ):
-        """
-        Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
-        provided.
-
-        name (str): Chemical symbol or symbols as in 'MgO' or 'NaCl'.
-        crystalstructure (str): Must be one of sc, fcc, bcc, hcp, diamond, zincblende,
-                                rocksalt, cesiumchloride, fluorite or wurtzite.
-        a (float): Lattice constant.
-        c (float): Lattice constant.
-        c_over_a (float): c/a ratio used for hcp.  Default is ideal ratio: sqrt(8/3).
-        u (float): Internal coordinate for Wurtzite structure.
-        orthorhombic (bool): Construct orthorhombic unit cell instead of primitive cell which is the default.
-        cubic (bool): Construct cubic unit cell if possible.
-
-        Returns:
-
-            pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
-        """
-        return StructureGenerator.create_ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c, covera=covera, u=u,
-                               orthorhombic=orthorhombic, cubic=cubic)
-
-    @staticmethod
     def create_atoms(
         symbols=None,
         positions=None,
@@ -519,32 +473,6 @@ class Project(ProjectCore):
             species=species,
             **qwargs
         )
-
-    @staticmethod
-    def create_surface(
-        element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=None, **kwargs
-    ):
-        """
-        Generate a surface based on the ase.build.surface module.
-
-        Args:
-            element (str): Element name
-            surface_type (str): The string specifying the surface type generators available through ase (fcc111,
-            hcp0001 etc.)
-            size (tuple): Size of the surface
-            vacuum (float): Length of vacuum layer added to the surface along the z direction
-            center (bool): Tells if the surface layers have to be at the center or at one end along the z-direction
-            pbc (list/numpy.ndarray): List of booleans specifying the periodic boundary conditions along all three
-                                      directions. If None, it is set to [True, True, True]
-            **kwargs: Additional, arguments you would normally pass to the structure generator like 'a', 'b',
-            'orthogonal' etc.
-
-        Returns:
-            pyiron.atomistics.structure.atoms.Atoms instance: Required surface
-
-        """
-        return StructureGenerator.create_surface(element=element, surface_type=surface_type,
-                              size=size, vacuum=vacuum, center=center, pbc=pbc, **kwargs)
 
     @staticmethod
     def inspect_periodic_table():
@@ -628,3 +556,96 @@ class Project(ProjectCore):
             FlexibleMaster:
         """
         return pipe(project=self, job=job, step_lst=step_lst, delete_existing_job=delete_existing_job)
+
+    # Deprecated methods
+
+    def create_ase_bulk(
+            self,
+            name,
+            crystalstructure=None,
+            a=None,
+            c=None,
+            covera=None,
+            u=None,
+            orthorhombic=False,
+            cubic=False,
+    ):
+        """
+        Deprecated as of v.0.3.12, please use `Project.structure.create_ase_bulk`.
+
+        Creating bulk systems using ASE bulk module. Crystal structure and lattice constant(s) will be guessed if not
+        provided.
+
+        name (str): Chemical symbol or symbols as in 'MgO' or 'NaCl'.
+        crystalstructure (str): Must be one of sc, fcc, bcc, hcp, diamond, zincblende,
+                                rocksalt, cesiumchloride, fluorite or wurtzite.
+        a (float): Lattice constant.
+        c (float): Lattice constant.
+        c_over_a (float): c/a ratio used for hcp.  Default is ideal ratio: sqrt(8/3).
+        u (float): Internal coordinate for Wurtzite structure.
+        orthorhombic (bool): Construct orthorhombic unit cell instead of primitive cell which is the default.
+        cubic (bool): Construct cubic unit cell if possible.
+
+        Returns:
+
+            pyiron.atomistics.structure.atoms.Atoms: Required bulk structure
+        """
+        warnings.warn(
+            "Project.create_ase_bulk is deprecated as of v0.3.12. Please use Project.structure.create_ase_bulk.",
+            DeprecationWarning
+        )
+        return self.structure.create_ase_bulk(name=name, crystalstructure=crystalstructure, a=a, c=c, covera=covera,
+                                              u=u, orthorhombic=orthorhombic, cubic=cubic)
+
+    def create_structure(self, element, bravais_basis, lattice_constant):
+        """
+        Deprecated as of v.0.3.12, please use `Project.structure.create_structure`.
+
+        Create a crystal structure using pyiron's native crystal structure generator
+
+        Args:
+            element (str): Element name
+            bravais_basis (str): Basis type
+            lattice_constant (float/list): Lattice constants
+
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms: The required crystal structure
+
+        """
+        warnings.warn(
+            "Project.create_structure is deprecated as of v0.3.12. Please use Project.structure.create_structure.",
+            DeprecationWarning
+        )
+        return self.structure.create_structure(element=element, bravais_basis=bravais_basis,
+                                               lattice_constant=lattice_constant)
+
+    def create_surface(
+            self, element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=None, **kwargs
+    ):
+        """
+        Deprecated as of v.0.3.12, please use `Project.structure.create_surface`.
+
+        Generate a surface based on the ase.build.surface module.
+
+        Args:
+            element (str): Element name
+            surface_type (str): The string specifying the surface type generators available through ase (fcc111,
+            hcp0001 etc.)
+            size (tuple): Size of the surface
+            vacuum (float): Length of vacuum layer added to the surface along the z direction
+            center (bool): Tells if the surface layers have to be at the center or at one end along the z-direction
+            pbc (list/numpy.ndarray): List of booleans specifying the periodic boundary conditions along all three
+                                      directions. If None, it is set to [True, True, True]
+            **kwargs: Additional, arguments you would normally pass to the structure generator like 'a', 'b',
+            'orthogonal' etc.
+
+        Returns:
+            pyiron.atomistics.structure.atoms.Atoms instance: Required surface
+
+        """
+        warnings.warn(
+            "Project.create_surface is deprecated as of v0.3.12. Please use Project.structure.create_surface.",
+            DeprecationWarning
+        )
+        return self.structure.create_surface(element=element, surface_type=surface_type, size=size, vacuum=vacuum,
+                                             center=center, pbc=pbc, **kwargs)

--- a/pyiron/project.py
+++ b/pyiron/project.py
@@ -479,8 +479,8 @@ class Project(ProjectCore):
         #     "Project.create_structure is deprecated as of v0.3. Please use Project.create.structure.structure.",
         #     DeprecationWarning
         # )
-        return self.create.structure.structure(element=element, bravais_basis=bravais_basis,
-                                               lattice_constant=lattice_constant)
+        return self.create.structure.crystal(element=element, bravais_basis=bravais_basis,
+                                             lattice_constant=lattice_constant)
 
     def create_surface(
             self, element, surface_type, size=(1, 1, 1), vacuum=1.0, center=False, pbc=None, **kwargs

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1290,19 +1290,19 @@ class TestAtoms(unittest.TestCase):
             basis_1 += basis_2
             self.assertEqual(len(w), 1)
         a_0 = 2.86
-        structure = self.struct_factory.structure('Fe', 'bcc', a_0)
+        structure = self.struct_factory.crystal('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]])
         structure += carbon
         self.assertEqual(carbon.indices[0], 0)
 
     def test_append(self):
         a_0 = 2.86
-        structure = self.struct_factory.structure('Fe', 'bcc', a_0)
+        structure = self.struct_factory.crystal('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]], pbc=True)
         with warnings.catch_warnings(record=True) as w:
             structure.append(carbon)
             self.assertEqual(len(w), 0)
-            structure = self.struct_factory.structure('Fe', 'bcc', a_0)
+            structure = self.struct_factory.crystal('Fe', 'bcc', a_0)
             carbon.cell = np.random.rand(3)
             structure.append(carbon)
             self.assertEqual(len(w), 1)

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -38,7 +38,7 @@ class TestAtoms(unittest.TestCase):
         C = Atom("C").element
         cls.C3 = Atoms([C, C, C], positions=[[0, 0, 0], [0, 0, 2], [0, 2, 0]])
         cls.C2 = Atoms(2 * [Atom("C")])
-        cls.g = StructureFactory()
+        cls.struct_factory = StructureFactory()
 
     def setUp(self):
         # These atoms are reset before every test.
@@ -1290,19 +1290,19 @@ class TestAtoms(unittest.TestCase):
             basis_1 += basis_2
             self.assertEqual(len(w), 1)
         a_0 = 2.86
-        structure = self.g.structure('Fe', 'bcc', a_0)
+        structure = self.struct_factory.structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]])
         structure += carbon
         self.assertEqual(carbon.indices[0], 0)
 
     def test_append(self):
         a_0 = 2.86
-        structure = self.g.structure('Fe', 'bcc', a_0)
+        structure = self.struct_factory.structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]], pbc=True)
         with warnings.catch_warnings(record=True) as w:
             structure.append(carbon)
             self.assertEqual(len(w), 0)
-            structure = self.g.structure('Fe', 'bcc', a_0)
+            structure = self.struct_factory.structure('Fe', 'bcc', a_0)
             carbon.cell = np.random.rand(3)
             structure.append(carbon)
             self.assertEqual(len(w), 1)
@@ -1484,19 +1484,19 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(struct.get_chemical_formula(), 'Mg4')
 
     def test_static_functions(self):
-        Al_bulk = self.g.ase_bulk("Al")
+        Al_bulk = self.struct_factory.ase_bulk("Al")
         self.assertIsInstance(Al_bulk, Atoms)
         self.assertTrue(all(Al_bulk.pbc))
-        surface = self.g.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
+        surface = self.struct_factory.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
         self.assertTrue(all(surface.pbc))
-        surface = self.g.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
+        surface = self.struct_factory.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
         self.assertTrue(all(surface.pbc[0:2]))
         self.assertFalse(surface.pbc[2])
         self.assertIsInstance(surface, Atoms)
-        hkl_surface = self.g.hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
+        hkl_surface = self.struct_factory.hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
         self.assertIsInstance(hkl_surface, Atoms)
         self.assertTrue(all(hkl_surface.pbc))
-        hkl_surface_center = self.g.hkl_surface(
+        hkl_surface_center = self.struct_factory.hkl_surface(
             Al_bulk, [10, 8, 7], layers=20, vacuum=10, center=True
         )
         mean_z = np.mean([p[2] for p in hkl_surface_center.positions])

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1493,10 +1493,10 @@ class TestAtoms(unittest.TestCase):
         self.assertTrue(all(surface.pbc[0:2]))
         self.assertFalse(surface.pbc[2])
         self.assertIsInstance(surface, Atoms)
-        hkl_surface = self.struct_factory.hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
+        hkl_surface = self.struct_factory.surface_hkl(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
         self.assertIsInstance(hkl_surface, Atoms)
         self.assertTrue(all(hkl_surface.pbc))
-        hkl_surface_center = self.struct_factory.hkl_surface(
+        hkl_surface_center = self.struct_factory.surface_hkl(
             Al_bulk, [10, 8, 7], layers=20, vacuum=10, center=True
         )
         mean_z = np.mean([p[2] for p in hkl_surface_center.positions])

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from pyiron.atomistics.structure.atom import Atom
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
-from pyiron.atomistics.structure.generator import StructureGenerator
+from pyiron.atomistics.structure.factory import StructureFactory
 from pyiron.atomistics.structure.sparse_list import SparseList
 from pyiron.atomistics.structure.periodic_table import PeriodicTable, ChemicalElement
 from pyiron_base import FileHDFio, ProjectHDFio, Project
@@ -38,7 +38,7 @@ class TestAtoms(unittest.TestCase):
         C = Atom("C").element
         cls.C3 = Atoms([C, C, C], positions=[[0, 0, 0], [0, 0, 2], [0, 2, 0]])
         cls.C2 = Atoms(2 * [Atom("C")])
-        cls.g = StructureGenerator()
+        cls.g = StructureFactory()
 
     def setUp(self):
         # These atoms are reset before every test.

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -1290,19 +1290,19 @@ class TestAtoms(unittest.TestCase):
             basis_1 += basis_2
             self.assertEqual(len(w), 1)
         a_0 = 2.86
-        structure = self.g.create_structure('Fe', 'bcc', a_0)
+        structure = self.g.structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]])
         structure += carbon
         self.assertEqual(carbon.indices[0], 0)
 
     def test_append(self):
         a_0 = 2.86
-        structure = self.g.create_structure('Fe', 'bcc', a_0)
+        structure = self.g.structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]], pbc=True)
         with warnings.catch_warnings(record=True) as w:
             structure.append(carbon)
             self.assertEqual(len(w), 0)
-            structure = self.g.create_structure('Fe', 'bcc', a_0)
+            structure = self.g.structure('Fe', 'bcc', a_0)
             carbon.cell = np.random.rand(3)
             structure.append(carbon)
             self.assertEqual(len(w), 1)
@@ -1484,19 +1484,19 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(struct.get_chemical_formula(), 'Mg4')
 
     def test_static_functions(self):
-        Al_bulk = self.g.create_ase_bulk("Al")
+        Al_bulk = self.g.ase_bulk("Al")
         self.assertIsInstance(Al_bulk, Atoms)
         self.assertTrue(all(Al_bulk.pbc))
-        surface = self.g.create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
+        surface = self.g.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
         self.assertTrue(all(surface.pbc))
-        surface = self.g.create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
+        surface = self.g.surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
         self.assertTrue(all(surface.pbc[0:2]))
         self.assertFalse(surface.pbc[2])
         self.assertIsInstance(surface, Atoms)
-        hkl_surface = self.g.create_hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
+        hkl_surface = self.g.hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
         self.assertIsInstance(hkl_surface, Atoms)
         self.assertTrue(all(hkl_surface.pbc))
-        hkl_surface_center = self.g.create_hkl_surface(
+        hkl_surface_center = self.g.hkl_surface(
             Al_bulk, [10, 8, 7], layers=20, vacuum=10, center=True
         )
         mean_z = np.mean([p[2] for p in hkl_surface_center.positions])

--- a/tests/atomistics/structure/test_atoms.py
+++ b/tests/atomistics/structure/test_atoms.py
@@ -8,7 +8,7 @@ import os
 import warnings
 from pyiron.atomistics.structure.atom import Atom
 from pyiron.atomistics.structure.atoms import Atoms, CrystalStructure
-from pyiron.atomistics.structure.generator import create_ase_bulk, create_surface, create_hkl_surface, create_structure
+from pyiron.atomistics.structure.generator import StructureGenerator
 from pyiron.atomistics.structure.sparse_list import SparseList
 from pyiron.atomistics.structure.periodic_table import PeriodicTable, ChemicalElement
 from pyiron_base import FileHDFio, ProjectHDFio, Project
@@ -38,6 +38,7 @@ class TestAtoms(unittest.TestCase):
         C = Atom("C").element
         cls.C3 = Atoms([C, C, C], positions=[[0, 0, 0], [0, 0, 2], [0, 2, 0]])
         cls.C2 = Atoms(2 * [Atom("C")])
+        cls.g = StructureGenerator()
 
     def setUp(self):
         # These atoms are reset before every test.
@@ -1289,19 +1290,19 @@ class TestAtoms(unittest.TestCase):
             basis_1 += basis_2
             self.assertEqual(len(w), 1)
         a_0 = 2.86
-        structure = create_structure('Fe', 'bcc', a_0)
+        structure = self.g.create_structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]])
         structure += carbon
         self.assertEqual(carbon.indices[0], 0)
 
     def test_append(self):
         a_0 = 2.86
-        structure = create_structure('Fe', 'bcc', a_0)
+        structure = self.g.create_structure('Fe', 'bcc', a_0)
         carbon = Atoms(symbols=['C'], positions=[[0, 0, 0.5 * a_0]], pbc=True)
         with warnings.catch_warnings(record=True) as w:
             structure.append(carbon)
             self.assertEqual(len(w), 0)
-            structure = create_structure('Fe', 'bcc', a_0)
+            structure = self.g.create_structure('Fe', 'bcc', a_0)
             carbon.cell = np.random.rand(3)
             structure.append(carbon)
             self.assertEqual(len(w), 1)
@@ -1483,19 +1484,19 @@ class TestAtoms(unittest.TestCase):
         self.assertEqual(struct.get_chemical_formula(), 'Mg4')
 
     def test_static_functions(self):
-        Al_bulk = create_ase_bulk("Al")
+        Al_bulk = self.g.create_ase_bulk("Al")
         self.assertIsInstance(Al_bulk, Atoms)
         self.assertTrue(all(Al_bulk.pbc))
-        surface = create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
+        surface = self.g.create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10)
         self.assertTrue(all(surface.pbc))
-        surface = create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
+        surface = self.g.create_surface("Al", "fcc111", size=(4, 4, 4), vacuum=10, pbc=[True, True, False])
         self.assertTrue(all(surface.pbc[0:2]))
         self.assertFalse(surface.pbc[2])
         self.assertIsInstance(surface, Atoms)
-        hkl_surface = create_hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
+        hkl_surface = self.g.create_hkl_surface(Al_bulk, [10, 8, 7], layers=20, vacuum=10)
         self.assertIsInstance(hkl_surface, Atoms)
         self.assertTrue(all(hkl_surface.pbc))
-        hkl_surface_center = create_hkl_surface(
+        hkl_surface_center = self.g.create_hkl_surface(
             Al_bulk, [10, 8, 7], layers=20, vacuum=10, center=True
         )
         mean_z = np.mean([p[2] for p in hkl_surface_center.positions])

--- a/tests/atomistics/volumetric/test_volumetric_data.py
+++ b/tests/atomistics/volumetric/test_volumetric_data.py
@@ -65,7 +65,7 @@ class TestVolumetricData(unittest.TestCase):
         vd = VolumetricData()
         n_x, n_y, n_z = (10, 15, 20)
         vd.total_data = np.random.rand(n_x, n_y, n_z)
-        struct = StructureGenerator.create_ase_bulk("Al")
+        struct = StructureGenerator.ase_bulk("Al")
         cyl_avg = vd.cylindrical_average_potential(struct, spherical_center=[0, 0, 0],
                                                    axis_of_cyl=2, rad=2, fwhm=0.529177)
         self.assertIsInstance(cyl_avg, float)

--- a/tests/atomistics/volumetric/test_volumetric_data.py
+++ b/tests/atomistics/volumetric/test_volumetric_data.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 from pyiron.atomistics.volumetric.generic import VolumetricData
 from pyiron.atomistics.structure.atoms import Atoms
-from pyiron.atomistics.structure.generator import create_ase_bulk
+from pyiron.atomistics.structure.generator import StructureGenerator
 from pyiron.vasp.volumetric_data import VaspVolumetricData
 
 
@@ -65,7 +65,7 @@ class TestVolumetricData(unittest.TestCase):
         vd = VolumetricData()
         n_x, n_y, n_z = (10, 15, 20)
         vd.total_data = np.random.rand(n_x, n_y, n_z)
-        struct = create_ase_bulk("Al")
+        struct = StructureGenerator.create_ase_bulk("Al")
         cyl_avg = vd.cylindrical_average_potential(struct, spherical_center=[0, 0, 0],
                                                    axis_of_cyl=2, rad=2, fwhm=0.529177)
         self.assertIsInstance(cyl_avg, float)

--- a/tests/atomistics/volumetric/test_volumetric_data.py
+++ b/tests/atomistics/volumetric/test_volumetric_data.py
@@ -7,7 +7,7 @@ import numpy as np
 import os
 from pyiron.atomistics.volumetric.generic import VolumetricData
 from pyiron.atomistics.structure.atoms import Atoms
-from pyiron.atomistics.structure.generator import StructureGenerator
+from pyiron.atomistics.structure.factory import StructureFactory
 from pyiron.vasp.volumetric_data import VaspVolumetricData
 
 
@@ -65,7 +65,7 @@ class TestVolumetricData(unittest.TestCase):
         vd = VolumetricData()
         n_x, n_y, n_z = (10, 15, 20)
         vd.total_data = np.random.rand(n_x, n_y, n_z)
-        struct = StructureGenerator.ase_bulk("Al")
+        struct = StructureFactory.ase_bulk("Al")
         cyl_avg = vd.cylindrical_average_potential(struct, spherical_center=[0, 0, 0],
                                                    axis_of_cyl=2, rad=2, fwhm=0.529177)
         self.assertIsInstance(cyl_avg, float)


### PR DESCRIPTION
The atomistic `Project` class already has a lot of methods for creating structures, and I can see that we will only have more coming. For instance, I want easy access to `ase.io.read`.

So here I package these methods up in a new class, and add that class as an attribute of `Project`. I.e. `project.create_ase_bulk('Al')` --> `project.structure.create_ase_bulk('Al')`. This is a bit more typing, but in cleans up and organizes our tab completion, and the class structure will help as we extend the ability for generating structures (e.g. making grain boundaries, dislocations, etc.)

What is *not* done here:
- New, nicely structured tests for the `StructureGenerator` class.
- Very many new extensions (only binding ASE's read).

What I most want feedback on is really serious thought as to what we should name this new attribute of `Project`, which I currently just call `structure`.