### PR TITLE
Fix potentials available

### DIFF
--- a/pyiron/lammps/potential.py
+++ b/pyiron/lammps/potential.py
@@ -281,16 +281,18 @@ class LammpsPotentialFile(PotentialAbstract):
 
 class PotentialAvailable(object):
     def __init__(self, list_of_potentials):
-        self._list_of_potentials = list_of_potentials
+        self._list_of_potentials = {
+            v.replace("-", "_"):v for v in list_of_potentials
+        }
 
     def __getattr__(self, name):
-        if name in self._list_of_potentials:
-            return name
+        if name in self._list_of_potentials.keys():
+            return self._list_of_potentials[name]
         else:
             raise AttributeError
 
     def __dir__(self):
-        return self._list_of_potentials
+        return list(self._list_of_potentials.keys())
 
     def __repr__(self):
         return str(dir(self))

--- a/pyiron/lammps/potential.py
+++ b/pyiron/lammps/potential.py
@@ -282,7 +282,7 @@ class LammpsPotentialFile(PotentialAbstract):
 class PotentialAvailable(object):
     def __init__(self, list_of_potentials):
         self._list_of_potentials = {
-            v.replace("-", "_"): v for v in list_of_potentials
+            "pot_" + v.replace("-", "_"): v for v in list_of_potentials
         }
 
     def __getattr__(self, name):

--- a/pyiron/lammps/potential.py
+++ b/pyiron/lammps/potential.py
@@ -282,7 +282,7 @@ class LammpsPotentialFile(PotentialAbstract):
 class PotentialAvailable(object):
     def __init__(self, list_of_potentials):
         self._list_of_potentials = {
-            v.replace("-", "_"):v for v in list_of_potentials
+            v.replace("-", "_"): v for v in list_of_potentials
         }
 
     def __getattr__(self, name):

--- a/pyiron/lammps/potential.py
+++ b/pyiron/lammps/potential.py
@@ -282,7 +282,7 @@ class LammpsPotentialFile(PotentialAbstract):
 class PotentialAvailable(object):
     def __init__(self, list_of_potentials):
         self._list_of_potentials = {
-            "pot_" + v.replace("-", "_"): v for v in list_of_potentials
+            "pot_" + v.replace("-", "_").replace('.', '_'): v for v in list_of_potentials
         }
 
     def __getattr__(self, name):


### PR DESCRIPTION
This is a bug fix to the potential_available property based on the recent changes to the potential database https://github.com/pyiron/pyiron/pull/1179 
This is not an implementation of the newly discussed `set_to` feature. 

Assign potentials using autocompletion: 
```
job.potential = job.potential_available.pot_2018__Jeong_G_U__Pd_Al__LAMMPS__ipr1
job.potential = '2018--Jeong-G-U--Pd-Al--LAMMPS--ipr1'
```
Both lines are equivalent - we have to add a string in front of the potential names, as some potential names start with a number and we have to replace `-` with `_`. 