### PR TITLE
Interface to lammps move

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -822,6 +822,12 @@ class LammpsControl(GenericParameters):
             ids (list/numpy.ndarray): Integer ids of the atoms to move in the job's structure.
             velocity (list/numpy.ndarray/tuple): The velocity in x-y-z-direction for the group. `None` arguments are
                 converted to Lammps 'NULL' values and the velocity in this direction is left unchanged.
+
+        Warning: This fix does not exclude these atoms from
+            [other fixes](https://stackoverflow.com/questions/3402168/permanently-add-a-directory-to-pythonpath). You
+            may wish to combine this call with `selective_dynamics` on your corresponding structure. Future developers
+            can find a more complete discussion [here](https://github.com/pyiron/pyiron/pull/1212) when further
+            modifying this capability.
         """
         self._fix_to_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -792,6 +792,10 @@ class LammpsControl(GenericParameters):
     def _set_group_by_id(self, group_name, ids):
         if len(ids) < 1:
             raise ValueError('Group ids must have at least length one, but got {}'.format(ids))
+        if not np.all([isinstance(id_, (int, np.int64)) for id_ in ids]):
+            raise TypeError('Group ids must be integers, but got {}'.format(ids))
+        if np.any(ids < 0):
+            raise ValueError('Group ids must be non-negative to be parsed by Lammps, but got {}'.format(ids))
         self['group___{}'.format(group_name)] = 'id {}'.format(' '.join(np.array(ids).astype(int).astype(str)))
 
     def fix_move_linear_by_id(self, ids, velocity):

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -839,6 +839,8 @@ class LammpsControl(GenericParameters):
         ids (list/numpy.ndarray): Integer ids of the atoms to move in the job's structure.
         force (list/numpy.ndarray/tuple): The force in x-y-z-direction for the group. `None` arguments are
             converted to Lammps 'NULL' values and the force in this direction is left unchanged.
+
+        Warning: This fix will malfunction (silently) if the Lammps coordinate frame and pyiron coordinate frame differ.
         """
         self._fix_with_three_vector(ids, force, 'setforce', LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"])
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -823,12 +823,11 @@ class LammpsControl(GenericParameters):
             velocity (list/numpy.ndarray/tuple): The velocity in x-y-z-direction for the group. `None` arguments are
                 converted to Lammps 'NULL' values and the velocity in this direction is left unchanged.
 
-        Warning: This fix does not exclude these atoms from
-            [other fixes](https://stackoverflow.com/questions/3402168/permanently-add-a-directory-to-pythonpath). You
-            may wish to combine this call with `selective_dynamics` on your corresponding structure. Future developers
-            can find a more complete discussion [here](https://github.com/pyiron/pyiron/pull/1212) when further
-            modifying this capability. Further, it will malfunction if the Lammps coordinate frame and pyiron coordinate
-            frame differ.
+        Warning: This fix does not exclude these atoms from [other fixes](https://lammps.sandia.gov/doc/fix_move.html).
+            You may wish to combine this call with `selective_dynamics` on your corresponding structure. Future
+            developers can find a more complete discussion [here](https://github.com/pyiron/pyiron/pull/1212) when
+            further modifying this capability. Further, it will malfunction if the Lammps coordinate frame and pyiron
+            coordinate frame differ.
         """
         self._fix_with_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -799,7 +799,7 @@ class LammpsControl(GenericParameters):
             raise ValueError('Group ids must be non-negative to be parsed by Lammps, but got {}'.format(ids))
         self['group___{}'.format(group_name)] = 'id {}'.format(' '.join(np.array(ids).astype(int).astype(str)))
 
-    def _fix_to_three_vector(self, ids, vector, fix_string, conversion):
+    def _fix_with_three_vector(self, ids, vector, fix_string, conversion):
         if len(vector) != 3:
             raise ValueError('{} must have three components, but got {}'.format(fix_string, vector))
         vector = list(vector)
@@ -829,7 +829,7 @@ class LammpsControl(GenericParameters):
             can find a more complete discussion [here](https://github.com/pyiron/pyiron/pull/1212) when further
             modifying this capability.
         """
-        self._fix_to_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
+        self._fix_with_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
 
     def fix_setforce_by_id(self, ids, force):
         """
@@ -839,7 +839,7 @@ class LammpsControl(GenericParameters):
         force (list/numpy.ndarray/tuple): The force in x-y-z-direction for the group. `None` arguments are
             converted to Lammps 'NULL' values and the force in this direction is left unchanged.
         """
-        self._fix_to_three_vector(ids, force, 'setforce', LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"])
+        self._fix_with_three_vector(ids, force, 'setforce', LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"])
 
     def _measure_mean_value(self, key_pyiron, key_lmp, every, atom=False):
         """

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -792,7 +792,7 @@ class LammpsControl(GenericParameters):
     def _set_group_by_id(self, group_name, ids):
         if len(ids) < 1:
             raise ValueError('Group ids must have at least length one, but got {}'.format(ids))
-        if np.any([isinstance(id_, bool) or not isinstance(id_, (int, np.int64)) for id_ in ids]):
+        if np.any([isinstance(id_, bool) or not isinstance(id_, (int, np.integer)) for id_ in ids]):
             # Note: it turns out bool is a subclass of int. Weird, eh.
             raise TypeError('Group ids must be integers, but got {}'.format(ids))
         if np.any(np.array(ids) < 0):

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -827,7 +827,8 @@ class LammpsControl(GenericParameters):
             [other fixes](https://stackoverflow.com/questions/3402168/permanently-add-a-directory-to-pythonpath). You
             may wish to combine this call with `selective_dynamics` on your corresponding structure. Future developers
             can find a more complete discussion [here](https://github.com/pyiron/pyiron/pull/1212) when further
-            modifying this capability.
+            modifying this capability. Further, it will malfunction if the Lammps coordinate frame and pyiron coordinate
+            frame differ.
         """
         self._fix_with_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
 

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -800,7 +800,8 @@ class LammpsControl(GenericParameters):
 
         Args:
             ids (list/numpy.ndarray): Integer ids of the atoms to move in the job's structure.
-            velocity (list/numpy.ndarray/tuple): The velocity in x-y-z-direction for the group. `None` arguments are OK.
+            velocity (list/numpy.ndarray/tuple): The velocity in x-y-z-direction for the group. `None` arguments are
+                converted to Lammps 'NULL' values and the velocity in this direction is left unchanged.
         """
         if len(velocity) != 3:
             raise ValueError('Velocity must have three components, but got {}'.format(velocity))

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -790,6 +790,8 @@ class LammpsControl(GenericParameters):
             self['dump_modify___1'] = self['dump_modify___1'][:-1] + ' %20.15g"'
 
     def _set_group_by_id(self, group_name, ids):
+        if len(ids) < 1:
+            raise ValueError('Group ids must have at least length one, but got {}'.format(ids))
         self['group___{}'.format(group_name)] = 'id {}'.format(' '.join(np.array(ids).astype(int).astype(str)))
 
     def fix_move_linear_by_id(self, ids, velocity):
@@ -800,6 +802,8 @@ class LammpsControl(GenericParameters):
             ids (list/numpy.ndarray): Integer ids of the atoms to move in the job's structure.
             velocity (list/numpy.ndarray/tuple): The velocity in x-y-z-direction for the group. `None` arguments are OK.
         """
+        if len(velocity) != 3:
+            raise ValueError('Velocity must have three components, but got {}'.format(velocity))
         conversion = LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"]
         velocity = list(velocity)
         for i, v in enumerate(velocity):

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -829,6 +829,9 @@ class LammpsControl(GenericParameters):
             further modifying this capability. Further, it will malfunction if the Lammps coordinate frame and pyiron
             coordinate frame differ.
         """
+        warnings.warn('This fix does not exclude these atoms from other fixes. You may wish to combine this call with '
+                      '`selective_dynamics` on your corresponding structure. Further, it will malfunction if the '
+                      'Lammps coordinate frame and pyiron coordinate frame differ.')
         self._fix_with_three_vector(ids, velocity, 'move linear', LAMMPS_UNIT_CONVERSIONS[self["units"]]["velocity"])
 
     def fix_setforce_by_id(self, ids, force):
@@ -841,6 +844,8 @@ class LammpsControl(GenericParameters):
 
         Warning: This fix will malfunction (silently) if the Lammps coordinate frame and pyiron coordinate frame differ.
         """
+        warnings.warn('This fix will malfunction (silently) if the Lammps coordinate frame and pyiron coordinate frame '
+                      'differ.')
         self._fix_with_three_vector(ids, force, 'setforce', LAMMPS_UNIT_CONVERSIONS[self["units"]]["force"])
 
     def _measure_mean_value(self, key_pyiron, key_lmp, every, atom=False):

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -792,9 +792,10 @@ class LammpsControl(GenericParameters):
     def _set_group_by_id(self, group_name, ids):
         if len(ids) < 1:
             raise ValueError('Group ids must have at least length one, but got {}'.format(ids))
-        if not np.all([isinstance(id_, (int, np.int64)) for id_ in ids]):
+        if np.any([isinstance(id_, bool) or not isinstance(id_, (int, np.int64)) for id_ in ids]):
+            # Note: it turns out bool is a subclass of int. Weird, eh.
             raise TypeError('Group ids must be integers, but got {}'.format(ids))
-        if np.any(ids < 0):
+        if np.any(np.array(ids) < 0):
             raise ValueError('Group ids must be non-negative to be parsed by Lammps, but got {}'.format(ids))
         self['group___{}'.format(group_name)] = 'id {}'.format(' '.join(np.array(ids).astype(int).astype(str)))
 

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -154,7 +154,7 @@ class TestLammps(unittest.TestCase):
 
     def test_fix_move_linear_by_id(self):
         fix = self.lc.fix_move_linear_by_id
-        good_ids = np.arange(4)
+        good_ids = np.arange(4, dtype=int)
         good_velocities = [None, -0.004, 0.001]
         fix(good_ids, good_velocities)
 

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -152,6 +152,24 @@ class TestLammps(unittest.TestCase):
         ):
             self.assertFalse(self.lc._is_isotropic_hydrostatic(nonisotropic_pressure))
 
+    def test_fix_move_linear_by_id(self):
+        fix = self.lc.fix_move_linear_by_id
+        good_ids = [1, 2, 3, 4]
+        good_velocities = [None, -0.004, 0.001]
+        fix(good_ids, good_velocities)
+
+        has_str = ['one', 2, 3]
+        has_list = [[1, 2, 3], 4, 5]
+        empty = []
+        self.assertRaises(ValueError, fix, has_str, good_velocities)
+        self.assertRaises(TypeError, fix, has_list, good_velocities)
+        self.assertRaises(ValueError, fix, empty, good_velocities)
+
+        self.assertRaises(TypeError, fix, good_ids, has_str)
+        self.assertRaises(TypeError, fix, good_ids, has_list)
+        self.assertRaises(ValueError, fix, good_ids, empty)
+        self.assertRaises(ValueError, fix, good_ids, np.arange(4))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/lammps/test_control.py
+++ b/tests/lammps/test_control.py
@@ -154,16 +154,18 @@ class TestLammps(unittest.TestCase):
 
     def test_fix_move_linear_by_id(self):
         fix = self.lc.fix_move_linear_by_id
-        good_ids = [1, 2, 3, 4]
+        good_ids = np.arange(4)
         good_velocities = [None, -0.004, 0.001]
         fix(good_ids, good_velocities)
 
         has_str = ['one', 2, 3]
         has_list = [[1, 2, 3], 4, 5]
         empty = []
-        self.assertRaises(ValueError, fix, has_str, good_velocities)
+        self.assertRaises(TypeError, fix, has_str, good_velocities)
         self.assertRaises(TypeError, fix, has_list, good_velocities)
         self.assertRaises(ValueError, fix, empty, good_velocities)
+        self.assertRaises(TypeError, fix, [True, True, False], good_velocities)
+        self.assertRaises(ValueError, fix, [-2, -1, 0], good_velocities)
 
         self.assertRaises(TypeError, fix, good_ids, has_str)
         self.assertRaises(TypeError, fix, good_ids, has_list)


### PR DESCRIPTION
A new lammps control interface to access [`fix move`](https://lammps.sandia.gov/doc/fix_move.html).

Currently tucked away hidden in `lammps.input.control` with no direct job access as it's probably just for experts/not something you can (currently) do in other codes(?).