### PR TITLE
Use new deprecate decorator

### DIFF
--- a/pyiron/atomistics/job/interactivewrapper.py
+++ b/pyiron/atomistics/job/interactivewrapper.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 import warnings
 from pyiron_base import GenericParameters, GenericJob, GenericMaster
+from pyiron_base.generic.util import deprecate
 from pyiron.atomistics.structure.atoms import ase_to_pyiron
 from pyiron.atomistics.structure.atoms import Atoms as PAtoms
 
@@ -108,16 +109,13 @@ class InteractiveWrapper(GenericMaster):
                 self._ref_job.master_id = self.job_id
                 self._ref_job.server.cores = self.server.cores
 
+    @deprecate("use get_structure() instead")
     def get_final_structure(self):
         """
 
         Returns:
 
         """
-        warnings.warn(
-            "get_final_structure() is deprecated - please use get_structure() instead.",
-            DeprecationWarning,
-        )
         if self.ref_job:
             return self._ref_job.get_structure(iteration_step=-1)
         else:

--- a/pyiron/atomistics/structure/atoms.py
+++ b/pyiron/atomistics/structure/atoms.py
@@ -21,6 +21,7 @@ from pyiron.atomistics.structure.periodic_table import (
     ChemicalElement
 )
 from pyiron_base import Settings
+from pyiron_base.generic.util import deprecate
 from scipy.spatial import cKDTree, Voronoi
 import spglib
 
@@ -864,13 +865,13 @@ class Atoms(ASEAtoms):
         # assert(len(self) == np.sum(self.get_number_species_atoms().values()))
         return len(self)
 
+    @deprecate
     def set_absolute(self):
-        warnings.warn("set_relative is deprecated as of 2020/02/26. It is not guaranteed from v. 0.3", DeprecationWarning)
         if self._is_scaled:
             self._is_scaled = False
 
+    @deprecate
     def set_relative(self):
-        warnings.warn("set_relative is deprecated as of 2020/02/26. It is not guaranteed from v. 0.3", DeprecationWarning)
         if not self._is_scaled:
             self._is_scaled = True
 
@@ -1480,16 +1481,15 @@ class Atoms(ASEAtoms):
             cutoff_radius=cutoff_radius,
         )
 
+    @deprecate("use neigh.find_neighbors_by_vector() instead (after calling neigh = structure.get_neighbors())",
+               version="1.0.0")
     def find_neighbors_by_vector(self, vector, return_deviation=False, num_neighbors=96):
-        warnings.warn(
-            'structure.find_neighbors_by_vector() is deprecated as of vers. 0.3.'
-            + 'It is not guaranteed to be in service in vers. 1.0.'
-            + 'Use neigh.find_neighbors_by_vector() instead (after calling neigh = structure.get_neighbors()).',
-            DeprecationWarning)
         neighbors = self.get_neighbors(num_neighbors=num_neighbors)
         return neighbors.find_neighbors_by_vector(vector=vector, return_deviation=return_deviation)
     find_neighbors_by_vector.__doc__ = Neighbors.find_neighbors_by_vector.__doc__
 
+    @deprecate("Use neigh.get_shell_matrix() instead (after calling neigh = structure.get_neighbors())",
+               version="1.0.0")
     def get_shell_matrix(
         self, id_list=None, chemical_pair=None, num_neighbors=100, tolerance=2,
         cluster_by_distances=False, cluster_by_vecs=False
@@ -1497,10 +1497,6 @@ class Atoms(ASEAtoms):
         neigh_list = self.get_neighbors(
             num_neighbors=num_neighbors, id_list=id_list, tolerance=tolerance
         )
-        warnings.warn('structure.get_shell_matrix() is deprecated as of vers. 0.3.'
-            + 'It is not guaranteed to be in service in vers. 1.0.'
-            + 'Use neigh.get_shell_matrix() instead (after calling neigh = structure.get_neighbors()).',
-            DeprecationWarning)
         return neigh_list.get_shell_matrix(
             chemical_pair=chemical_pair,
             cluster_by_distances=cluster_by_distances,
@@ -1535,6 +1531,8 @@ class Atoms(ASEAtoms):
         self.set_species(new_species)
         self.indices = new_indices
 
+    @deprecate("Use neigh.cluster_analysis() instead (after calling neigh = structure.get_neighbors())",
+               version="1.0.0")
     def cluster_analysis(
         self, id_list, neighbors=None, radius=None, return_cluster_sizes=False
     ):
@@ -1549,10 +1547,6 @@ class Atoms(ASEAtoms):
         Returns:
 
         """
-        warnings.warn('structure.cluster_analysis() is deprecated as of vers. 0.3.'
-            + 'It is not guaranteed to be in service in vers. 1.0.'
-            + 'Use neigh.cluster_analysis() instead (after calling neigh = structure.get_neighbors()).',
-            DeprecationWarning)
         if neighbors is None:
             if radius is None:
                 neigh = self.get_neighbors(num_neighbors=100)
@@ -1564,6 +1558,8 @@ class Atoms(ASEAtoms):
         return neighbors.cluster_analysis(id_list=id_list, return_cluster_sizes=return_cluster_sizes)
 
     # TODO: combine with corresponding routine in plot3d
+    @deprecate("Use neigh.get_bonds() instead (after calling neigh = structure.get_neighbors())",
+               version="1.0.0")
     def get_bonds(self, radius=np.inf, max_shells=None, prec=0.1, num_neighbors=20):
         """
 
@@ -1576,10 +1572,6 @@ class Atoms(ASEAtoms):
         Returns:
 
         """
-        warnings.warn('structure.cluster_analysis() is deprecated as of vers. 0.3.'
-            + 'It is not guaranteed to be in service in vers. 1.0.'
-            + 'Use neigh.cluster_analysis() instead (after calling neigh = structure.get_neighbors()).',
-            DeprecationWarning)
         neighbors = self.get_neighbors_by_distance(
             cutoff_radius=radius, num_neighbors=num_neighbors
         )

--- a/pyiron/lammps/base.py
+++ b/pyiron/lammps/base.py
@@ -16,6 +16,7 @@ from io import StringIO
 from pyiron.lammps.potential import LammpsPotentialFile, PotentialAvailable
 from pyiron.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_base import Settings, extract_data_from_file
+from pyiron_base.generic.util import deprecate
 from pyiron.lammps.control import LammpsControl
 from pyiron.lammps.potential import LammpsPotential
 from pyiron.lammps.structure import LammpsStructure, UnfoldingPrism
@@ -254,16 +255,13 @@ class LammpsBase(AtomisticGenericJob):
         """
         return self.list_potentials()
 
+    @deprecate("use get_structure() instead")
     def get_final_structure(self):
         """
 
         Returns:
 
         """
-        warnings.warn(
-            "get_final_structure() is deprecated - please use get_structure() instead.",
-            DeprecationWarning,
-        )
         return self.get_structure(iteration_step=-1)
 
     def view_potentials(self):

--- a/pyiron/vasp/potential.py
+++ b/pyiron/vasp/potential.py
@@ -10,6 +10,7 @@ import pandas
 import tables
 import warnings
 from pyiron_base import GenericParameters, Settings
+from pyiron_base.generic.util import deprecate
 from pyiron.atomistics.job.potentials import PotentialAbstract, find_potential_file_base
 
 __author__ = "Jan Janssen"
@@ -273,6 +274,7 @@ def find_potential_file(path):
     )
 
 
+@deprecate("use get_enmax_among_potentials and note the adjustment to the signature (*args instead of list)")
 def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
     """
     DEPRECATED: Please use `get_enmax_among_potentials`.
@@ -289,8 +291,6 @@ def get_enmax_among_species(symbol_lst, return_list=False, xc="PBE"):
         (float): The largest ENMAX among the POTCAR files for all the species.
         [optional](list): The ENMAX value corresponding to each species.
     """
-    warnings.warn(("get_enmax_among_species is deprecated as of v0.3.0. Please use get_enmax_among_potentials and note "
-                   + "the adjustment to the signature (*args instead of list)"), DeprecationWarning)
     return get_enmax_among_potentials(*symbol_lst, return_list=return_list, xc=xc)
 
 


### PR DESCRIPTION
As anticipated there are a lot of instances where we only deprecate some arguments to a function, I will handle this in the next iteration of the decorator in pyiron_base and then update here.

There also some cases that I don't know how to handle, like this

https://github.com/pyiron/pyiron/blob/d410e585babd3b07326853de38134bd182b528bd/pyiron/lammps/interactive.py#L113

It'd be nice to also have them be handled by the `Deprecator`, to keep the messages uniform.  I'm thinking to expose a method there that just logs the warning and this method would be called in the decorator, but it would also be available manually.  If you have opinions on this, let me know.