### PR TITLE
Switching off k-mesh spacing by k_mesh_spacing=None

### DIFF
--- a/pyiron/dft/job/generic.py
+++ b/pyiron/dft/job/generic.py
@@ -270,6 +270,8 @@ class GenericDFTJob(AtomisticGenericJob):
             if mesh is not None:
                 warnings.warn("mesh value is overwritten by k_mesh_spacing")
             mesh = self.get_k_mesh_by_cell(k_mesh_spacing=k_mesh_spacing)
+        elif self.k_mesh_spacing is not None: # switching off k_mesh_spacing would preserve the current mesh
+            mesh = self.get_k_mesh_by_cell(k_mesh_spacing=self.k_mesh_spacing)
         self.k_mesh_spacing = k_mesh_spacing
         self.k_mesh_center_shift = center_shift
         self.reduce_kpoint_symmetry = symmetry_reduction


### PR DESCRIPTION
Switching off by `k_mesh_spacing=None` would **preserve** the current k-mesh, not reset it, i.e.:
```python
ref_job.set_kpoints(k_mesh_spacing=0.1)
# kmesh=[15,15,15]
ref_job.set_kpoints(k_mesh_spacing=None)
# kmesh remains [15,15,15]
```