### PR TITLE
Remove redundant lines in LAMMPS input control

### DIFF
--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -337,8 +337,10 @@ class LammpsControl(GenericParameters):
             + str(int(max_evaluations))
         )
         self.remove_keys(["run", "velocity"])
-        self.modify(variable___dumptime="equal " + str(n_print))
-        self.modify(variable___thermotime="equal " + str(n_print))
+        self.modify(
+            variable___dumptime="equal " + str(n_print),
+            variable___thermotime="equal " + str(n_print)
+        )
 
     def calc_static(self):
         self.set(run="0")

--- a/pyiron/lammps/control.py
+++ b/pyiron/lammps/control.py
@@ -337,8 +337,8 @@ class LammpsControl(GenericParameters):
             + str(int(max_evaluations))
         )
         self.remove_keys(["run", "velocity"])
-        self.modify(variable___dumptime="equal " + str(n_print), thermo=n_print)
-        self.modify(variable___thermotime="equal " + str(n_print), thermo=n_print)
+        self.modify(variable___dumptime="equal " + str(n_print))
+        self.modify(variable___thermotime="equal " + str(n_print))
 
     def calc_static(self):
         self.set(run="0")
@@ -578,14 +578,7 @@ class LammpsControl(GenericParameters):
         self.modify(
             fix___ensemble=fix_ensemble_str,
             variable___dumptime=" equal {} ".format(n_print),
-            thermo=int(n_print),
-            run=int(n_ionic_steps),
-            append_if_not_present=True,
-        )
-        self.modify(
-            fix___ensemble=fix_ensemble_str,
             variable___thermotime=" equal {} ".format(n_print),
-            thermo=int(n_print),
             run=int(n_ionic_steps),
             append_if_not_present=True,
         )


### PR DESCRIPTION
remove one redundant self.modify and forbid changing thermo value directly. I'm not really sure if it was okay to delete `thermo=value`, but since we are defining `thermotime` I guess we shouldn't change `thermo` directly.