### PR TITLE
update structure setter for interactive jobs

### DIFF
--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -629,8 +629,8 @@ class AtomisticGenericJob(GenericJobCore):
         Returns:
             pyiron.atomistics.structure.atoms.Atoms: The required structure
         """
-        if not (self.structure is not None):
-            raise AssertionError()
+        if self.structure is None:
+            raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
         conditions = list()
         if isinstance(self.output.cells, (list, np.ndarray)):

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -637,7 +637,7 @@ class AtomisticGenericJob(GenericJobCore):
             snapshot.cell = self.output.cells[iteration_step]
         except IndexError:
             if wrap_atoms:
-                raise IndexError('cell at step ', iteraction_step, ' not found')
+                raise IndexError('cell at step ', iteration_step, ' not found')
             snapshot.cell = None
         try:
             snapshot.indices = self.output.indices[iteration_step]

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -622,6 +622,7 @@ class AtomisticGenericJob(GenericJobCore):
         """
         Gets the structure from a given iteration step of the simulation (MD/ionic relaxation). For static calculations
         there is only one ionic iteration step
+
         Args:
             iteration_step (int): Step for which the structure is requested
             wrap_atoms (bool): True if the atoms are to be wrapped back into the unit cell
@@ -632,15 +633,20 @@ class AtomisticGenericJob(GenericJobCore):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
-        snapshot.cell = self.output.cells[iteration_step]
+        try:
+            snapshot.cell = self.output.cells[iteration_step]
+        except IndexError:
+            if wrap_atoms:
+                raise IndexError('cell at step ', iteraction_step, ' not found')
+            snapshot.cell = None
         try:
             snapshot.indices = self.output.indices[iteration_step]
         except IndexError:
             pass
         if wrap_atoms:
             snapshot.positions = self.output.positions[iteration_step]
-            return snapshot.center_coordinates_in_unit_cell()
-        if len(self.output.unwrapped_positions) > max([iteration_step, 0]):
+            snapshot.center_coordinates_in_unit_cell()
+        elif len(self.output.unwrapped_positions) > max([iteration_step, 0]):
             snapshot.positions = self.output.unwrapped_positions[iteration_step]
         else:
             snapshot.positions += self.output.total_displacements[iteration_step]

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -632,25 +632,19 @@ class AtomisticGenericJob(GenericJobCore):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
-        try:
-            snapshot.cell = self.output.cells[iteration_step]
-        except IndexError:
-            pass
+        snapshot.cell = self.output.cells[iteration_step]
         try:
             snapshot.indices = self.output.indices[iteration_step]
         except IndexError:
             pass
-        try:
-            if wrap_atoms:
-                snapshot.positions = self.output.positions[iteration_step]
-                return snapshot.center_coordinates_in_unit_cell()
-            if len(self.output.unwrapped_positions) > max([iteration_step, 0]):
-                snapshot.positions = self.output.unwrapped_positions[iteration_step]
-            else:
-                snapshot.positions += self.output.total_displacements[iteration_step]
-            return snapshot
-        except IndexError:
-            return snapshot
+        if wrap_atoms:
+            snapshot.positions = self.output.positions[iteration_step]
+            return snapshot.center_coordinates_in_unit_cell()
+        if len(self.output.unwrapped_positions) > max([iteration_step, 0]):
+            snapshot.positions = self.output.unwrapped_positions[iteration_step]
+        else:
+            snapshot.positions += self.output.total_displacements[iteration_step]
+        return snapshot
 
     def map(self, function, parameter_lst):
         master = self.create_job(

--- a/pyiron/atomistics/job/atomistic.py
+++ b/pyiron/atomistics/job/atomistic.py
@@ -632,30 +632,24 @@ class AtomisticGenericJob(GenericJobCore):
         if self.structure is None:
             raise AssertionError('Structure not set')
         snapshot = self.structure.copy()
-        conditions = list()
-        if isinstance(self.output.cells, (list, np.ndarray)):
-            if len(self.output.cells) == 0:
-                conditions.append(True)
-            else:
-                conditions.append(self.output.cells[0] is None)
-        if self.output.positions is not None and self.output.cells is None:
-            conditions.append(self.output.cells is None)
-        if any(conditions):
-            snapshot.cell = None
-        elif self.output.cells is not None:
+        try:
             snapshot.cell = self.output.cells[iteration_step]
-        if self.output.positions is not None:
-            snapshot.positions = self.output.positions[iteration_step]
-        indices = self.output.indices
-        if indices is not None and len(indices) > max([iteration_step, 0]):
-            snapshot.indices = indices[iteration_step]
-        if wrap_atoms:
-            return snapshot.center_coordinates_in_unit_cell()
-        else:
+        except IndexError:
+            pass
+        try:
+            snapshot.indices = self.output.indices[iteration_step]
+        except IndexError:
+            pass
+        try:
+            if wrap_atoms:
+                snapshot.positions = self.output.positions[iteration_step]
+                return snapshot.center_coordinates_in_unit_cell()
             if len(self.output.unwrapped_positions) > max([iteration_step, 0]):
                 snapshot.positions = self.output.unwrapped_positions[iteration_step]
             else:
                 snapshot.positions += self.output.total_displacements[iteration_step]
+            return snapshot
+        except IndexError:
             return snapshot
 
     def map(self, function, parameter_lst):

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -121,7 +121,7 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
             self.interactive_initialize_interface()
         if self._structure_previous is None:
             self._structure_previous = self.structure.copy()
-        self.update_previous_structure()
+        self._update_previous_structure()
         if self._structure_current is not None:
             if (
                 len(self._structure_current) != len(self._structure_previous)
@@ -268,7 +268,7 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
     def interactive_volume_getter(self):
         return self.initial_structure.get_volume()
 
-    def update_previous_structure(self):
+    def _update_previous_structure(self):
         """
         Update the previous structure to the last step configuration
         Args:

--- a/pyiron/atomistics/job/interactive.py
+++ b/pyiron/atomistics/job/interactive.py
@@ -274,19 +274,20 @@ class GenericInteractive(AtomisticGenericJob, InteractiveBase):
         Args:
             wrap_atoms (bool):
         """
-        if self.output.indices is None or len(self.output.indices) == 0:
-            return
-        indices = self.output.indices[-1]
-        if indices is None:
+        try:
+            indices = self.output.indices[-1]
+            positions = self.output.positions[-1]
+            cell = self.output.cells[-1]
+        except IndexError:
             return
         if len(self._interactive_species_lst) == 0:
             el_lst = [el.Abbreviation for el in self.structure.species]
         else:
             el_lst = self._interactive_species_lst.tolist()
-        self._structure_previous.positions = self.output.positions[-1]
         self._structure_previous.set_species([self._periodic_table.element(el) for el in el_lst])
         self._structure_previous.indices = indices
-        self._structure_previous.cell = self.output.cells[-1]
+        self._structure_previous.positions = positions
+        self._structure_previous.cell = cell
 
     @staticmethod
     def _extend_species_elements(struct_species, species_array):

--- a/pyiron/testing/randomatomistic.py
+++ b/pyiron/testing/randomatomistic.py
@@ -390,12 +390,12 @@ class AtomisticExampleJob(ExampleJob, GenericInteractive):
         return self._structure
 
     def get_structure(self, iteration_step=-1, wrap_atoms=True):
-        structure = super(AtomisticExampleJob, self).get_structure(
-            iteration_step=iteration_step, wrap_atoms=wrap_atoms
-        )
-        if structure is None:
+        try:
+            return super(AtomisticExampleJob, self).get_structure(
+                iteration_step=iteration_step, wrap_atoms=wrap_atoms
+            )
+        except IndexError:
             return self.structure
-        return structure
 
     @structure.setter
     def structure(self, structure):


### PR DESCRIPTION
I wanted to make sure that also for interactive jobs the tags are copied. But then I realised that the `get_structure` in `atomistic.py` has little utility, and moreover in the interactive jobs the structure is copied at each step, which significantly reduces the efficiency. So I removed `get_structure` from `atomistic.py` (which makes you use only the one defined in `GenericAtomisticJob`) and introduced `_update_previous_structure`, which only updates the information and does not copy an entire structure.