### PR TITLE
Use matplotlib-base rather than matplotlib in conda environment

### DIFF
--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - defusedxml >=0.6.0
   - future >=0.18.2
   - h5py >=3.1.0
-  - matplotlib >=3.3.3
+  - matplotlib-base >=3.3.3
   - mendeleev >=0.6.1
   - molmod >=1.4.8
   - numpy >=1.19.4


### PR DESCRIPTION
We do not need `pyqt` so using `matplotlib-base` should be faster: 
https://conda-forge.org/docs/maintainer/knowledge_base.html#matplotlib