### PR TITLE
Remove pypi support for python versions not allowed by conda

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@ setup(
                  'License :: OSI Approved :: BSD License',
                  'Intended Audience :: Science/Research',
                  'Operating System :: OS Independent',
-                 'Programming Language :: Python :: 3.6',
-                 'Programming Language :: Python :: 3.7',
-                 'Programming Language :: Python :: 3.8',
                  'Programming Language :: Python :: 3.9',
                  'Programming Language :: Python :: 3.10'],
 


### PR DESCRIPTION
Synchronizes the pypi representation of pyiron with the hard limit of python >3.8 expressed on [the conda forge feedstock](https://github.com/conda-forge/pyiron-feedstock/blob/c954babdba3bcd313738db2feeae0de6412a9123/recipe/meta.yaml#L24)