### PR TITLE
Require latest version of pyiron-data

### DIFF
--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -11,6 +11,6 @@ dependencies:
 - sphinxdft >=2.7.0
 - sphinxdft-data
 - iprpy-data
-- pyiron-data >=0.0.27
+- pyiron-data >=0.0.29
 - pymatgen
 - sqsgenerator


### PR DESCRIPTION
The tests in `pyiron_atomistics` work fine while the ones here in `pyiron` break. Maybe the easiest way is just to release a new `pyiron_atomistics` version and then check again. 