### PR TITLE
Add workshop on the doc page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -96,6 +96,7 @@ Read more about `citing individual modules/ plugins of pyiron and the implemente
    source/about.rst
    source/installation.rst
    source/examples.rst
+   Workshops <https://github.com/pyiron-workshop>
    Team <https://pyiron.org/team/>
    Collaborators <https://pyiron.org/collaborators/>
    source/commandline.rst


### PR DESCRIPTION
Following [@aageo25's request](https://github.com/pyiron/FAQs/issues/57) I added `Workshops` right below `Examples`.